### PR TITLE
Feature/cloudinary integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,6 +65,8 @@ defaults:
     layout: post
     permalink: "/authors/:slug/"
 
+cloudinary_url: https://res.cloudinary.com/csisideaslab/image/upload/
+
 # Build settings
 markdown: kramdown
 

--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,8 @@ defaults:
   values:
     layout: post
     permalink: "/themes/:slug/"
+- scope:
+    path: ''
     type: 'events'
   values:
     layout: post

--- a/_events/commission-launch.md
+++ b/_events/commission-launch.md
@@ -22,6 +22,10 @@ references: ''
 ---
 The CSIS Commission on Strengthening America’s Health Security officially launched on April 17, 2018. Commissioners gathered to discuss the major objectives of the Commission for its two-year life span.
 
+![testing](https://via.placeholder.com/350x150 "test")
+
+![testing](https://res.cloudinary.com/csisideaslab/image/upload/v1536943052/health-commission/photo-1529928750697-1d9646312221.jpg "test")
+
 Commission Co-Chairs Julie Gerberding and Kelly Ayotte offered opening remarks, followed by a discussion led by the Congressional members of the Commission on the macro-objectives for the Commission and its role in shaping the discourse on health security among U.S. policymakers. The Commissioners then engaged in three simulation scenarios, involving MERS, biotechnology, and North Korea, to illuminate the health security considerations and decision-making points for a U.S. response in such situations. Following the scenarios, Julie and Kelly led discussion of the five theme focal areas of the Commission – preventing and responding to high-risk disease outbreaks; winning the fight against antimicrobial drug resistance; managing the promise and threat of evolving biotechnology; accelerating medical countermeasures; and protecting health security in a disordered world.
 
 The Commissioners identified health security as an area with bipartisan support in Congress and recognized the opportunity for the Commission to raise awareness and understanding on health security among Congressional policymakers. The Commissioners highlighted the reality of the disordered world as a novel prism for illuminating many health security challenges. Discussion also acknowledged the need for a broader approach connecting the national security, health, and Congressional communities as is necessary to prepare for crisis situations and strengthen response to health emergencies. The future work of the Commission builds on these and other outcomes from the launch discussion.

--- a/_includes/cloudinary-responsive-img.html
+++ b/_includes/cloudinary-responsive-img.html
@@ -1,4 +1,5 @@
-{% if include.path %}
+{% if include.path.size > 0 %}
+{% if include.path contains 'cloudinary' %}
 {% assign image_name = include.path | split: "/upload/" | last %}
 <img
   sizes="(max-width: 320px) 320px,
@@ -13,4 +14,7 @@
           {{ site.cloudinary_url }}f_auto,w_800/{{ image_name }} 800w"
   src="{{ site.cloudinary_url }}f_auto,w_800/v1536943052/health-commission/{{ image_name }}" title="{{ include.alt }}"
   alt="{{ include.alt }}" />
+{% else %}
+<img src="{{ include.path }}" title="{{ include.alt }}" alt="{{ include.alt }}" />
+{% endif %}
 {% endif %}

--- a/_includes/cloudinary-responsive-img.html
+++ b/_includes/cloudinary-responsive-img.html
@@ -1,0 +1,16 @@
+{% if include.path %}
+{% assign image_name = include.path | split: "/upload/" | last %}
+<img
+  sizes="(max-width: 320px) 320px,
+        (max-width: 375px) 335px,
+        (max-width: 480px) 440px,
+        (max-width: 675px) 635px,
+        800px"
+  srcset="{{ site.cloudinary_url }}f_auto,q_70,w_320/{{ image_name }} 320w,
+          {{ site.cloudinary_url }}f_auto,q_70,w_335/{{ image_name }} 335w,
+          {{ site.cloudinary_url }}f_auto,q_70,w_480/{{ image_name }} 480w,
+          {{ site.cloudinary_url }}f_auto,q_70,w_635/{{ image_name }} 635w,
+          {{ site.cloudinary_url }}f_auto,w_800/{{ image_name }} 800w"
+  src="{{ site.cloudinary_url }}f_auto,w_800/v1536943052/health-commission/{{ image_name }}" title="{{ include.alt }}"
+  alt="{{ include.alt }}" />
+{% endif %}

--- a/_plugins/responsive-images.rb
+++ b/_plugins/responsive-images.rb
@@ -1,9 +1,9 @@
 # Finds images in markdown files and replace them with a cloudinary responsive image include
-Jekyll::Hooks.register :posts, :pre_render do |post, payload|
+Jekyll::Hooks.register :documents, :pre_render do |post, payload|
   docExt = post.extname.tr('.', '')
   # only process if we deal with a markdown file
   if payload['site']['markdown_ext'].include? docExt
-    newContent = post.content.gsub(/\!\[(.+)\]\((.+)"(.+)"\)/, '{% include cloudinary-responsive-img.html path="\2" alt="\1" %}')
+    newContent = post.content.gsub(/\!\[(.*)?\]\((.*?)(?=\"|\))(\".*\")?\)/, '{% include cloudinary-responsive-img.html title="\1" alt=\3 path="\2" %}')
     post.content = newContent
   end
 end

--- a/_plugins/responsive-images.rb
+++ b/_plugins/responsive-images.rb
@@ -1,0 +1,9 @@
+# Finds images in markdown files and replace them with a cloudinary responsive image include
+Jekyll::Hooks.register :posts, :pre_render do |post, payload|
+  docExt = post.extname.tr('.', '')
+  # only process if we deal with a markdown file
+  if payload['site']['markdown_ext'].include? docExt
+    newContent = post.content.gsub(/\!\[(.+)\]\((.+)"(.+)"\)/, '{% include cloudinary-responsive-img.html path="\2" alt="\1" %}')
+    post.content = newContent
+  end
+end

--- a/frasco.config.js
+++ b/frasco.config.js
@@ -3,11 +3,11 @@ module.exports = {
 
   tasks: {
     browsersync: true,
-    eslint:      true,
-    imagemin:    true,
-    sass:        true,
-    watch:       true,
-    webpack:     true,
+    eslint: true,
+    imagemin: true,
+    sass: true,
+    watch: true,
+    webpack: true
   },
 
   assets: './assets',
@@ -23,65 +23,60 @@ module.exports = {
       // "Safari",
       // "Opera",
       // "Opera Developer",
-    ],
+    ]
   },
 
   eslintLoader: {
-    enforce: "pre",
-    test:    /\.js$/,
+    enforce: 'pre',
+    test: /\.js$/,
     exclude: /node_modules/,
-    loader:  "eslint-loader",
+    loader: 'eslint-loader'
   },
 
   imagemin: {
-    src:         '_images',
-    dest:        'images',
+    src: '_images',
+    dest: 'images',
     progressive: true,
-    svgoPlugins: [{removeViewBox: false}],
+    svgoPlugins: [{ removeViewBox: false }]
   },
 
   jekyll: {
     config: {
-      default:     '_config.yml',
+      default: '_config.yml',
       development: '_config_development.yml',
-      production:  '',
+      production: ''
     },
-    dest:     '_site',
-    data:     '_data',
+    dest: '_site',
+    data: '_data',
     includes: '_includes',
-    layouts:  '_layouts',
-    posts:    '_posts',
-    series:   '_series',
-    themes:   '_themes',
-    events:   '_events',
-    authors:  '_authors',
+    layouts: '_layouts',
+    posts: '_posts',
+    series: '_series',
+    themes: '_themes',
+    events: '_events',
+    authors: '_authors',
+    plugins: '_plugins'
   },
 
   js: {
-    src:   '_js',
-    dest:  'js',
-    entry: [
-      'bundle.js'
-    ],
+    src: '_js',
+    dest: 'js',
+    entry: ['bundle.js']
   },
 
   sass: {
-    src:          '_sass',
-    dest:         'css',
-    outputStyle:  'compressed',
+    src: '_sass',
+    dest: 'css',
+    outputStyle: 'compressed',
     autoprefixer: {
-      browsers: [
-        '> 1%',
-        'last 2 versions',
-        'Firefox ESR',
-      ],
-    },
+      browsers: ['> 1%', 'last 2 versions', 'Firefox ESR']
+    }
   },
 
   webpack: {
-    mode:   'production',
+    mode: 'production',
     module: {
-      rules: [],
-    },
-  },
+      rules: []
+    }
+  }
 }


### PR DESCRIPTION
Close #44 by setting up the site to work with Cloudinary.

- The API keys and other configuration was set in Forestry to ensure images uploaded via the media library are hosted on Cloudinary
- Images used both in front matter and inside posts themselves will be pulled from Cloudinary
- A custom converter was created to automatically convert Cloudinary images inside post content to use an `<img>` tag with `size` and `srcset` values set. This will allow Cloudinary to automatically generate images based on what the browser requests