### PR TITLE
Create archive pages

### DIFF
--- a/.forestry/front_matter/templates/authors.yml
+++ b/.forestry/front_matter/templates/authors.yml
@@ -10,7 +10,7 @@ fields:
   name: short_title
   label: Short Title
 - type: textarea
-  name: short_bio
+  name: excerpt
   label: Short Bio
   config:
     wysiwyg: true

--- a/_authors/admiral-jonathan-greenert.md
+++ b/_authors/admiral-jonathan-greenert.md
@@ -5,7 +5,7 @@ role: ''
 short_title: U.S. Navy (former)
 long_title: Former Chief of Naval Operations, U.S. Navy
 has_photo: true
-short_bio: "**Admiral Jonathan Greenert** is the John M. Shalikashvili Chair in National
+excerpt: "**Admiral Jonathan Greenert** is the John M. Shalikashvili Chair in National
   Security Studies at The National Bureau of Asian Research (NBR). At NBR, Admiral
   Greenert informs debates on critical issues in the Asia-Pacific. He previously served
   as the 30th chief of naval operations from 2011 to 2015."

--- a/_authors/amanda-glassman.md
+++ b/_authors/amanda-glassman.md
@@ -6,7 +6,7 @@ role: ''
 short_title: Center for Global Development
 long_title: Chief Operating Officer and Senior Fellow, Center for Global Development
 has_photo: true
-short_bio: "**Amanda Glassman** is chief operating officer and senior fellow at the
+excerpt: "**Amanda Glassman** is chief operating officer and senior fellow at the
   Center for Global Development. Her research focuses on priority-setting, resource
   allocation and value for money in global health. Previously, she served as director
   for global health policy at the Center from 2010 to 2016, and principal technical

--- a/_authors/ambassador-jimmy-kolker.md
+++ b/_authors/ambassador-jimmy-kolker.md
@@ -6,7 +6,7 @@ short_title: U.S. Department of Health and Human Services (former)
 long_title: Former Assistant Secretary for Global Affairs, U.S. Department of Health
   and Human Services
 has_photo: true
-short_bio: "**Ambassador Jimmy Kolker** is a non-resident senior associate with the
+excerpt: "**Ambassador Jimmy Kolker** is a non-resident senior associate with the
   CSIS Global Health Policy Center. He retired in January 2017 as Assistant Secretary
   for Global Affairs at the U.S. Department of Health and Human Services (HHS), where
   he served as the Department’s chief health diplomat. His 30-year State Foreign Service

--- a/_authors/ambassador-karl-hofmann.md
+++ b/_authors/ambassador-karl-hofmann.md
@@ -5,7 +5,7 @@ role: ''
 short_title: Population Services International
 long_title: President and CEO, Population Services International
 has_photo: true
-short_bio: "**Ambassador Karl Hofmann** is the President and CEO of Population Services
+excerpt: "**Ambassador Karl Hofmann** is the President and CEO of Population Services
   International (PSI), a non-profit global health organization based in Washington,
   D.C. PSI operates in over 50 countries worldwide, with programs in family planning
   and reproductive health, malaria, water and sanitation, HIV, and non-communicable

--- a/_authors/ambassador-mark-dybul.md
+++ b/_authors/ambassador-mark-dybul.md
@@ -6,7 +6,7 @@ short_title: Georgetown University Medical Center
 long_title: Faculty Co-Director, Center for Global Health and Quality and Professor,
   Department of Medicine, Georgetown University Medical Center
 has_photo: true
-short_bio: "**Ambassador Mark Dybul** is the faculty director of the Center for Global
+excerpt: "**Ambassador Mark Dybul** is the faculty director of the Center for Global
   Health and Quality at the Georgetown University Medical Center, which seeks to work
   with international partners to respond to pressing global health challenges. A well-recognized
   global health expert and humanitarian, Dybul has served as head of both the Global

--- a/_authors/author-3.md
+++ b/_authors/author-3.md
@@ -2,6 +2,6 @@
 title: Missing Author 3
 date: 2018-09-14 17:20:27 +0000
 short_title: ''
-short_bio: ''
+excerpt: ''
 
 ---

--- a/_authors/beth-cameron.md
+++ b/_authors/beth-cameron.md
@@ -7,7 +7,7 @@ short_title: Nuclear Threat Initiative
 long_title: Vice President, Global Biological Policy and Programs, Nuclear Threat
   Initiative
 has_photo: true
-short_bio: "**Beth Cameron** is the Vice President for Global Biological Policy and
+excerpt: "**Beth Cameron** is the Vice President for Global Biological Policy and
   Programs at the Nuclear Threat Initiative (NTI), where she leads NTI | bio’s efforts
   to reduce global catastrophic biological risks, advance international biosecurity
   capability, and improve pandemic preparedness. She previously helped develop and

--- a/_authors/christine-wormuth.md
+++ b/_authors/christine-wormuth.md
@@ -5,7 +5,7 @@ role: ''
 short_title: RAND Corporation
 long_title: Director, International Security and Defense Policy Center, RAND Corporation
 has_photo: true
-short_bio: "**Christine Wormuth** is the director of the International Security and
+excerpt: "**Christine Wormuth** is the director of the International Security and
   Defense Policy Center at RAND Corporation. Prior to joining RAND, she was director
   of the Adrienne Arsht Center for Resilience at the Atlantic Council and Under-Secretary
   of Defense for Policy (USDP) at the U.S. Department of Defense."

--- a/_authors/david-a-relman.md
+++ b/_authors/david-a-relman.md
@@ -7,7 +7,7 @@ short_title: Stanford University
 long_title: Thomas C. and Joan M. Merigan Professor, Departments of Medicine and of
   Microbiology & Immunology, Stanford University
 has_photo: true
-short_bio: "**David A. Relman** is the Thomas C. and Joan M. Merigan Professor in
+excerpt: "**David A. Relman** is the Thomas C. and Joan M. Merigan Professor in
   the Departments of Medicine, and of Microbiology & Immunology, and Senior Fellow
   at the Freeman Spogli Institute for International Studies at Stanford University.
   He is also Chief of Infectious Diseases at the Veterans Affairs Palo Alto Health

--- a/_authors/emily-foecke-munden.md
+++ b/_authors/emily-foecke-munden.md
@@ -6,7 +6,7 @@ role: ''
 short_title: CSIS
 long_title: Associate Fellow, Global Health Policy Center, CSIS
 has_photo: true
-short_bio: "**Emily Foecke Munden** is an associate fellow with the CSIS Global Health
+excerpt: "**Emily Foecke Munden** is an associate fellow with the CSIS Global Health
   Policy Center, with a primary focus on global health security efforts. Previously,
   Ms. Munden worked in corporate global sourcing, led a maternal health nonprofit
   in Sierra Leone, and performed program design and implementation for irrigation

--- a/_authors/general-carter-ham.md
+++ b/_authors/general-carter-ham.md
@@ -5,7 +5,7 @@ role: ''
 short_title: U.S. Army (former)
 long_title: Former Commander of United States Africa Command, U.S. Army
 has_photo: true
-short_bio: "**General Carter Ham** is the President and Chief Executive Officer of
+excerpt: "**General Carter Ham** is the President and Chief Executive Officer of
   the Association of the United States Army. He is an experienced leader who has led
   at every level from platoon to geographic combatant command. He is also a member
   of a very small group of Army senior leaders who have risen from private to four-star

--- a/_authors/j-stephen-morrison.md
+++ b/_authors/j-stephen-morrison.md
@@ -6,7 +6,7 @@ role: ''
 short_title: CSIS
 long_title: Senior Vice President and Director, Global Health Policy Center, CSIS
 has_photo: true
-short_bio: "**J. Stephen Morrison** is senior vice president at the Center for Strategic
+excerpt: "**J. Stephen Morrison** is senior vice president at the Center for Strategic
   and International Studies (CSIS) and director of its Global Health Policy Center.
   Dr. Morrison writes widely, has directed several high-level commissions, and is
   a frequent commentator on U.S. foreign policy, global health, Africa, and foreign

--- a/_authors/jeffrey-l-sturchio.md
+++ b/_authors/jeffrey-l-sturchio.md
@@ -6,7 +6,7 @@ role: ''
 short_title: Rabin Martin
 long_title: President and CEO, Rabin Martin
 has_photo: false
-short_bio: "**Jeffrey L. Sturchio** is President & CEO of Rabin Martin, a global health
+excerpt: "**Jeffrey L. Sturchio** is President & CEO of Rabin Martin, a global health
   strategy consulting firm. Jeff is a global health thought leader and trusted counselor
   for senior leaders in the private sector, multilateral organizations, governments,
   NGOs and foundations."

--- a/_authors/jennifer-kates.md
+++ b/_authors/jennifer-kates.md
@@ -7,7 +7,7 @@ short_title: Kaiser Family Foundation
 long_title: Vice President and Director of Global Health & HIV Policy, Kaiser Family
   Foundation
 has_photo: true
-short_bio: "**Jennifer Kates** is Vice President and Director of Global Health & HIV
+excerpt: "**Jennifer Kates** is Vice President and Director of Global Health & HIV
   Policy at the Kaiser Family Foundation, where she oversees the Foundation’s policy
   analysis and research focused on the U.S. government’s role in global health and
   on the global and domestic HIV epidemics."

--- a/_authors/jeremy-konyndyk.md
+++ b/_authors/jeremy-konyndyk.md
@@ -6,7 +6,7 @@ role: ''
 short_title: Center for Global Development
 long_title: Senior Policy Fellow, Center for Global Development
 has_photo: true
-short_bio: "**Jeremy Konyndyk** is a senior policy fellow at the Center for Global
+excerpt: "**Jeremy Konyndyk** is a senior policy fellow at the Center for Global
   Development. His research focuses on humanitarian response, USAID policy reform,
   and global outbreak preparedness. He previously served in the Obama Administration
   from 2013-2017 as the director of USAID’s Office of US Foreign Disaster Assistance

--- a/_authors/jim-greenwood.md
+++ b/_authors/jim-greenwood.md
@@ -5,7 +5,7 @@ role: ''
 short_title: Biotechnology Innovation Organization
 long_title: President and CEO, Biotechnology Innovation Organization
 has_photo: true
-short_bio: "**Jim Greenwood** is President and CEO of the Biotechnology Innovation
+excerpt: "**Jim Greenwood** is President and CEO of the Biotechnology Innovation
   Organization (BIO) in Washington, D.C. BIO represents 1,000 biotechnology companies,
   academic institutions, state biotechnology centers, and related organizations across
   the United States and in more than 30 countries worldwide. Greenwood previously

--- a/_authors/juan-zarate.md
+++ b/_authors/juan-zarate.md
@@ -6,6 +6,6 @@ short_title: ''
 long_title: Senior Adviser, Transnational Threats Project and Human Rights Initiative,
   CSIS
 has_photo: false
-short_bio: ''
+excerpt: ''
 
 ---

--- a/_authors/julie-louise-gerberding-m-d-mph.md
+++ b/_authors/julie-louise-gerberding-m-d-mph.md
@@ -5,19 +5,10 @@ role: Co-Chair
 short_title: Merck & Co, Inc.
 long_title: Executive Vice President and Chief Patient Officer, Merck & Co, Inc.
 has_photo: true
-short_bio: "**Dr. Julie Gerberding** is Executive Vice President and Chief Patient
+
+---
+**Dr. Julie Gerberding** is Executive Vice President and Chief Patient
   Officer at Merck, where she is responsible for patient engagement, communications,
   policy, philanthropic and other functions. She joined Merck in 2010 as president
   of Merck Vaccines. Dr. Gerberding previously served as Director of the U.S. Centers
-  for Disease Control and Prevention (CDC) from 2002 to 2009."
-
----
-**Dr. Julie Gerberding** is Executive Vice President and Chief Patient Officer at Merck and is responsible for a broad portfolio of patient engagement, communications, policy, philanthropic and other functions. She joined Merck in 2010 as president, Merck Vaccines.  
-  
-Dr. Gerberding served as Director of the U.S. Centers for Disease Control and Prevention (CDC) from 2002 to 2009. She led the agency through more than 40 emergency responses to public health crises.   
-  
-Dr. Gerberding has received more than 50 awards and honors, including the United States Department of Health and Human Services Distinguished Service Award for her leadership in responses to anthrax bioterrorism and the September 11, 2001 attacks. She was named to Forbes Magazine's 100 Most Powerful Women in the world from 2005-2008 and to TIME Magazine's 100 Most Influential People in the World in 2004. In 2018, she was named the Healthcare Business Women’s Association Woman of the Year.  
-  
-Dr. Gerberding received her undergraduate and M.D. degrees from Case Western Reserve University. She completed her internship and residency in Internal Medicine and fellowship in Clinical Pharmacology and Infectious Diseases at the University of California, San Francisco, where she is currently an Adjunct Associate Professor of Medicine. Dr. Gerberding received a Masters of Public Health at the University of California, Berkeley. She is a member of the National Academy of Medicine and a fellow of the Infectious Diseases Society of America and the American College of Physicians. She is board certified in Internal Medicine and Infectious Diseases.  
-  
-She serves on the Boards of Cerner Corporation and the MSD Wellcome Trust Hilleman Laboratories, a non-profit that develops new technologies for developing countries.
+  for Disease Control and Prevention (CDC) from 2002 to 2009.

--- a/_authors/kelly-ayotte.md
+++ b/_authors/kelly-ayotte.md
@@ -5,7 +5,7 @@ name: Kelly Ayotte
 role: Co-Chair
 short_title: ''
 has_photo: false
-short_bio: ''
+excerpt: ''
 Title: Former Senator (NH)
 long_title: Former Senator (NH)
 

--- a/_authors/laura-s-h-holgate-ambassador-ret.md
+++ b/_authors/laura-s-h-holgate-ambassador-ret.md
@@ -5,7 +5,7 @@ role: ''
 short_title: Nuclear Threat Initiative
 long_title: Vice President, Materials Risk Management, Nuclear Threat Initiative
 has_photo: true
-short_bio: "**Ambassador Laura Holgate** is the Vice President for Materials Risk
+excerpt: "**Ambassador Laura Holgate** is the Vice President for Materials Risk
   Management at the Nuclear Threat Initiative. Previously, she served as U.S. Representative
   to the Vienna Office of the United Nations and the International Atomic Energy Agency
   and as Special Assistant to the President and Senior Director for Weapons of Mass

--- a/_authors/margaret-peggy-hamburg.md
+++ b/_authors/margaret-peggy-hamburg.md
@@ -5,7 +5,7 @@ role: ''
 short_title: National Academy of Medicine
 long_title: Foreign Secretary, National Academy of Medicine
 has_photo: true
-short_bio: "**Margaret “Peggy” Hamburg** is the foreign secretary of the National
+excerpt: "**Margaret “Peggy” Hamburg** is the foreign secretary of the National
   Academy of Medicine (NAM) and 2018 president of the American Association for the
   Advancement of Science (AAAS). Hamburg previously served as commissioner of the
   U.S. Food and Drug Administration from 2009 to 2015."

--- a/_authors/missing-author-2.md
+++ b/_authors/missing-author-2.md
@@ -2,6 +2,6 @@
 title: Missing Author 2
 date: 2018-09-14 16:59:49 +0000
 short_title: Placeholder for Missing Author2
-short_bio: ''
+excerpt: ''
 
 ---

--- a/_authors/missing-author-4.md
+++ b/_authors/missing-author-4.md
@@ -2,6 +2,6 @@
 title: Missing Author 4
 date: 2018-09-14 17:32:00 +0000
 short_title: ''
-short_bio: ''
+excerpt: ''
 
 ---

--- a/_authors/nancy-lindborg.md
+++ b/_authors/nancy-lindborg.md
@@ -5,7 +5,7 @@ role: ''
 short_title: United States Institute of Peace
 long_title: President, United States Institute of Peace
 has_photo: true
-short_bio: "**Nancy Lindborg** is the President of the United States Institute of
+excerpt: "**Nancy Lindborg** is the President of the United States Institute of
   Peace, an independent institution founded by Congress to provide practical solutions
   for preventing and resolving violent conflict around the world. Previously, she
   served as the assistant administrator for the Bureau for Democracy, Conflict and

--- a/_authors/rebecca-hersman.md
+++ b/_authors/rebecca-hersman.md
@@ -6,7 +6,7 @@ short_title: CSIS
 long_title: Director, Project on Nuclear Issues, and Senior Adviser, International
   Security Program, CSIS
 has_photo: true
-short_bio: "**Rebecca Hersman** directs the CSIS Project on Nuclear Issues and is
+excerpt: "**Rebecca Hersman** directs the CSIS Project on Nuclear Issues and is
   a senior adviser for the International Security Program. Ms. Hersman joined CSIS
   in April 2015 from the Department of Defense (DOD), where she served as deputy assistant
   secretary of defense for countering weapons of mass destruction (WMD) since 2009."

--- a/_authors/rebecca-katz.md
+++ b/_authors/rebecca-katz.md
@@ -7,7 +7,7 @@ short_title: Georgetown University
 long_title: Associate Professor and Director, Center for Global Health Science and
   Security, Georgetown University
 has_photo: true
-short_bio: "**Rebecca Katz** is an Associate Professor and Director of the Center
+excerpt: "**Rebecca Katz** is an Associate Professor and Director of the Center
   for Global Health Science and Security at Georgetown University. Prior to coming
   to Georgetown, she spent ten years at The George Washington University as faculty
   in the Milken Institute School of Public Health. Her research is focused on global

--- a/_authors/rocco-casagrande.md
+++ b/_authors/rocco-casagrande.md
@@ -6,7 +6,7 @@ role: ''
 short_title: Gryphon Scientific
 long_title: Managing Director, Gryphon Scientific
 has_photo: true
-short_bio: "**Rocco Casagrande** is the Managing Director of Gryphon Scientific and
+excerpt: "**Rocco Casagrande** is the Managing Director of Gryphon Scientific and
   a widely respected thought leader on defense against weapons of mass destruction
   and managing the safety and security risks of cutting-edge biological research.
   Dr. Casagrande began his public-sector career as a U.N. weapons inspector in pre-war

--- a/_authors/samantha-stroman.md
+++ b/_authors/samantha-stroman.md
@@ -7,7 +7,7 @@ short_title: CSIS
 long_title: Program Coordinator and Research Assistant, Global Health Policy Center,
   CSIS
 has_photo: true
-short_bio: "**Samantha Stroman** is a program coordinator and research assistant with
+excerpt: "**Samantha Stroman** is a program coordinator and research assistant with
   the CSIS Global Health Policy Center, with a focus on global health security."
 
 ---

--- a/_authors/steve-davis.md
+++ b/_authors/steve-davis.md
@@ -5,7 +5,7 @@ role: ''
 short_title: PATH
 long_title: President and CEO, PATH
 has_photo: true
-short_bio: "**Steve Davis**, president and CEO of PATH, is a social innovator and
+excerpt: "**Steve Davis**, president and CEO of PATH, is a social innovator and
   global health problem-solver who has been both a human rights lawyer and internet
   pioneer. Before joining PATH, Steve was director of Social Innovation at McKinsey
   & Company, CEO of the global digital media firm Corbis, and interim director of

--- a/_authors/tom-frieden.md
+++ b/_authors/tom-frieden.md
@@ -5,7 +5,7 @@ role: ''
 short_title: Resolve to Save Lives
 long_title: President and CEO, Resolve to Save Lives, an initiative of Vital Strategies
 has_photo: true
-short_bio: "**Tom Frieden** is President and Chief Executive Officer of Resolve to
+excerpt: "**Tom Frieden** is President and Chief Executive Officer of Resolve to
   Save Lives, a $225 million, 5-year initiative housed at Vital Strategies, a non-profit
   global health organization working toward the vision that all people are protected
   by a strong public health system. Dr. Frieden was Director of the Centers for Disease

--- a/_authors/tom-inglesby.md
+++ b/_authors/tom-inglesby.md
@@ -7,7 +7,7 @@ short_title: Johns Hopkins Bloomberg School of Public Health
 long_title: Director, Center for Health Security, Johns Hopkins Bloomberg School of
   Public Health
 has_photo: true
-short_bio: "**Tom Inglesby** is the Director of the Center for Health Security of
+excerpt: "**Tom Inglesby** is the Director of the Center for Health Security of
   the Johns Hopkins Bloomberg School of Public Health. Dr. Inglesby is also Professor
   in the Department of Environmental Health and Engineering in the Johns Hopkins Bloomberg
   School of Public Health with a Joint Appointment in the Johns Hopkins School of

--- a/_authors/trevor-mundel.md
+++ b/_authors/trevor-mundel.md
@@ -5,7 +5,7 @@ role: ''
 short_title: Bill & Melinda Gates Foundation
 long_title: President, Global Health Division, Bill & Melinda Gates Foundation
 has_photo: true
-short_bio: "**Trevor Mundel** is the president of the Global Health Division at the
+excerpt: "**Trevor Mundel** is the president of the Global Health Division at the
   Bill and Melinda Gates Foundation, where he leads the foundation’s efforts to develop
   high-impact interventions against the leading causes of death and disability in
   developing countries. Previously, Trevor was global head of development with Novartis."

--- a/_authors/u-s-congressman-ami-bera.md
+++ b/_authors/u-s-congressman-ami-bera.md
@@ -5,7 +5,7 @@ role: ''
 short_title: D-CA-7
 long_title: D-CA-7
 has_photo: true
-short_bio: "**Congressman Ami Bera** represents California’s 7th Congressional District
+excerpt: "**Congressman Ami Bera** represents California’s 7th Congressional District
   and is the Vice Ranking Member on the House Foreign Affairs Committee. Before being
   elected to Congress, Rep. Bera practiced medicine, served as Chief Medical Officer
   for Sacramento County, directed care management at a seven-hospital system, and

--- a/_authors/u-s-congressman-tom-cole.md
+++ b/_authors/u-s-congressman-tom-cole.md
@@ -5,6 +5,6 @@ role: ''
 short_title: ''
 long_title: R-OK
 has_photo: false
-short_bio: ''
+excerpt: ''
 
 ---

--- a/_authors/u-s-congresswoman-anna-eshoo.md
+++ b/_authors/u-s-congresswoman-anna-eshoo.md
@@ -5,7 +5,7 @@ role: ''
 short_title: D-CA-18
 long_title: D-CA-18
 has_photo: true
-short_bio: "**Congresswoman Anna Eshoo** is the current representative from California’s
+excerpt: "**Congresswoman Anna Eshoo** is the current representative from California’s
   18th district. For over two decades in Congress, she has defended consumers, promoted
   American competitiveness and innovation, fought for access to health care for families
   and children, protected the environment, and encouraged development of clean energy

--- a/_authors/u-s-senator-patty-murray.md
+++ b/_authors/u-s-senator-patty-murray.md
@@ -5,7 +5,7 @@ role: ''
 short_title: D-WA
 long_title: D-WA
 has_photo: true
-short_bio: "**Senator Patty Murray** is the senior Senator from the state of Washington.
+excerpt: "**Senator Patty Murray** is the senior Senator from the state of Washington.
   Serving as a member of Senate Democratic leadership since 2007, Senator Murray has
   established herself as a tireless and effective leader on education, transportation,
   budget issues, port security, healthcare, women, and veterans’ issues. She is currently

--- a/_authors/u-s-senator-todd-young.md
+++ b/_authors/u-s-senator-todd-young.md
@@ -5,7 +5,7 @@ role: ''
 short_title: R-IN
 long_title: R-IN
 has_photo: true
-short_bio: "**Senator Todd Young** represents Hoosiers in the United States Senate.
+excerpt: "**Senator Todd Young** represents Hoosiers in the United States Senate.
   He currently serves on the Senate Committees on Foreign Relations; Health, Education,
   Labor & Pensions; Commerce, Science & Transportation; and Small Business and Entrepreneurship."
 

--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ defaults:
     path: ''
     type: 'series'
   values:
-    layout: post
+    layout: archive
     permalink: "/series/:slug/"
 - scope:
     path: ''
@@ -64,7 +64,7 @@ defaults:
     path: ''
     type: 'authors'
   values:
-    layout: post
+    layout: archive
     permalink: "/authors/:slug/"
 
 cloudinary_url: https://res.cloudinary.com/csisideaslab/image/upload/

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -6,12 +6,8 @@ layout: default
   {% include page-header.html %}
   <section class="archive__header">
     <div class="post__header-meta">
-      {% if page.collection == 'authors' %}
-      <p>{{ page.short_bio | markdownify }}</p>
-      {% else %}
-      {{ page.excerpt | remove: '
-      <p>' | remove: '</p>' }}
-      {% endif %}
+      <p class="post__excerpt">{{ page.excerpt | remove: '
+        <p>' | remove: '</p>' }}</p>
     </div>
     {{ excerpt }}
     Pagination<br />

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -1,0 +1,36 @@
+---
+layout: default
+---
+<article class="archive archive--{{ page.title | slugify }}" role="content" itemscope itemtype="http://schema.org/BlogPosting">
+
+  {% include page-header.html %}
+  <section class="archive__header">
+    <div class="post__header-meta">
+      {% if page.collection == 'authors' %}
+      <p>{{ page.short_bio | markdownify }}</p>
+      {% else %}
+      {{ page.excerpt | remove: '
+      <p>' | remove: '</p>' }}
+      {% endif %}
+    </div>
+    {{ excerpt }}
+    Pagination<br />
+      Search Filtering
+  </section>
+  <section class="archive__content e-content" itemprop="articleBody">
+
+    {% if page.post_list_collection == 'all' %}
+    {% assign posts = site.posts | concat: site.events %}
+    {% else %}
+    {% assign posts = site[page.post_list_collection] %}
+    {% endif %}
+
+    {%- for post in posts -%}
+      {% include post-block.html %}
+    {%- endfor -%}
+  </section>
+  <footer class="archive__footer" role="footer">
+    Pagination
+  </footer>
+  <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+</article>

--- a/articles.md
+++ b/articles.md
@@ -1,0 +1,6 @@
+---
+layout: archive
+title: All Articles
+permalink: /articles/
+post_list_collection: posts
+---

--- a/assets/_sass/main.scss
+++ b/assets/_sass/main.scss
@@ -19,5 +19,6 @@
 @import 'components/post-block';
 @import 'components/post-further-reading';
 
+@import 'pages/archive';
 @import 'pages/post';
 @import 'pages/themes';

--- a/assets/_sass/pages/_archive.scss
+++ b/assets/_sass/pages/_archive.scss
@@ -1,0 +1,42 @@
+/*===============================
+=            Archive            =
+===============================*/
+
+.archive {
+  .page-header {
+    margin-bottom: 0;
+    min-height: 400px;
+  }
+
+  &__header {
+
+    .post__header-meta {
+      position: relative;
+      background-color: $color-light-gray;
+      padding-top: 2rem;
+      padding-bottom: 2rem;
+      @include fullWidthBackground($color-light-gray);
+
+      @include breakpoint('medium') {
+        background-color: transparent;
+
+        &::before,
+        &::after {
+          display: none;
+        }
+      }
+
+      p {
+        @extend %body-text;
+        font-style: normal;
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  &__content {
+    max-width: $size-page-text-max-width;
+    margin: 0 auto 3rem;
+  }
+}
+

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -26,6 +26,7 @@
     }
   }
 
+  &__header-meta p,
   &__excerpt {
     @extend %post-intro;
   }

--- a/authors.md
+++ b/authors.md
@@ -1,0 +1,6 @@
+---
+layout: archive
+title: All Authors
+permalink: /authors/
+post_list_collection: authors
+---

--- a/events.md
+++ b/events.md
@@ -1,0 +1,6 @@
+---
+layout: archive
+title: All Events
+permalink: /events/
+post_list_collection: events
+---

--- a/search.md
+++ b/search.md
@@ -1,0 +1,6 @@
+---
+layout: archive
+title: Search
+permalink: /search/
+post_list_collection: all
+---

--- a/series.md
+++ b/series.md
@@ -1,0 +1,6 @@
+---
+layout: archive
+title: Series
+permalink: /series/
+post_list_collection: series
+---

--- a/themes.md
+++ b/themes.md
@@ -1,0 +1,6 @@
+---
+layout: archive
+title: Themes
+permalink: /themes/
+post_list_collection: themes
+---


### PR DESCRIPTION
Starts implementation of #38. Creates the archive layout for articles, events, series, themes, authors, and search. 

Archive pages have a `post_list_collection` front matter field that specifies which collections to pull content from.

This needs the page highlights component, search functionality, and pagination components to be completed before the issue can be fully closed. 