### PR TITLE
remove version from image urls

### DIFF
--- a/_events/commission-launch.md
+++ b/_events/commission-launch.md
@@ -23,7 +23,7 @@ The CSIS Commission on Strengthening America’s Health Security officially laun
 
 ![testing](https://via.placeholder.com/350x150 "test")
 
-![testing](https://res.cloudinary.com/csisideaslab/image/upload/v1536943052/health-commission/photo-1529928750697-1d9646312221.jpg "test")
+![testing](https://res.cloudinary.com/csisideaslab/image/upload/v2/health-commission/photo-1529928750697-1d9646312221.jpg "test")
 
 Commission Co-Chairs Julie Gerberding and Kelly Ayotte offered opening remarks, followed by a discussion led by the Congressional members of the Commission on the macro-objectives for the Commission and its role in shaping the discourse on health security among U.S. policymakers. The Commissioners then engaged in three simulation scenarios, involving MERS, biotechnology, and North Korea, to illuminate the health security considerations and decision-making points for a U.S. response in such situations. Following the scenarios, Julie and Kelly led discussion of the five theme focal areas of the Commission – preventing and responding to high-risk disease outbreaks; winning the fight against antimicrobial drug resistance; managing the promise and threat of evolving biotechnology; accelerating medical countermeasures; and protecting health security in a disordered world.
 

--- a/_includes/cloudinary-responsive-img.html
+++ b/_includes/cloudinary-responsive-img.html
@@ -12,7 +12,7 @@
           {{ site.cloudinary_url }}f_auto,q_70,w_480/{{ image_name }} 480w,
           {{ site.cloudinary_url }}f_auto,q_70,w_635/{{ image_name }} 635w,
           {{ site.cloudinary_url }}f_auto,w_800/{{ image_name }} 800w"
-  src="{{ site.cloudinary_url }}f_auto,w_800/v1536943052/health-commission/{{ image_name }}" title="{{ include.alt }}"
+  src="{{ site.cloudinary_url }}f_auto,w_800/v2/health-commission/{{ image_name }}" title="{{ include.alt }}"
   alt="{{ include.alt }}" />
 {% else %}
 <img src="{{ include.path }}" title="{{ include.alt }}" alt="{{ include.alt }}" />

--- a/_includes/members-listing.html
+++ b/_includes/members-listing.html
@@ -10,7 +10,7 @@
     {% for member in site.data[group.type] %}
     <div class="group__member">
       {% assign file = member['Last Name'] | append: "_" | append: member['First Name'] | append: ".jpg" %}
-      {% assign path = site.cloudinary_url | append: "r_max/v1536943052/health-commission/" %}
+      {% assign path = site.cloudinary_url | append: "r_max/v2/health-commission/" %}
       {% assign placeholder = "Anon.jpg"  %}
 
       <img class="group__member__photo" onerror="this.src='{{ path }}{{ placeholder }}'" src="{{ path }}{{ file }}" />

--- a/_includes/members.html
+++ b/_includes/members.html
@@ -11,7 +11,7 @@
     {% for member in site.data[group.type] %}
     <div class="group__member">
       {% assign file = member['Last Name'] | append: "_" | append: member['First Name'] | append: ".jpg" %}
-      {% assign path = site.cloudinary_url | append: "r_max/v1536943052/health-commission/" %}
+      {% assign path = site.cloudinary_url | append: "r_max/v2/health-commission/" %}
       {% assign placeholder = "Anon.jpg"  %}
 
       <img class="group__member__photo" onerror="this.src='{{ path }}{{ placeholder }}'" src="{{ path }}{{ file }}" />

--- a/_posts/2018-02-14-welcome-to-jekyll.markdown
+++ b/_posts/2018-02-14-welcome-to-jekyll.markdown
@@ -3,7 +3,7 @@ layout: post
 title: Welcome to Jekyll!
 date: 2018-02-13 15:56:34 +0000
 categories: jekyll update
-image: https://res.cloudinary.com/csisideaslab/image/upload/v1536943052/health-commission/photo-1529928750697-1d9646312221.jpg
+image: https://res.cloudinary.com/csisideaslab/image/upload/v2/health-commission/photo-1529928750697-1d9646312221.jpg
 image_caption: This is a test caption.
 image_credit: Getty Images
 authors:
@@ -35,7 +35,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
-![testing](https://res.cloudinary.com/csisideaslab/image/upload/v1536943052/health-commission/photo-1529928750697-1d9646312221.jpg "test")
+![testing](https://res.cloudinary.com/csisideaslab/image/upload/v2/health-commission/photo-1529928750697-1d9646312221.jpg "test")
 
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
 

--- a/members.json
+++ b/members.json
@@ -1,6 +1,6 @@
 ---
 ---
-{% assign path = site.cloudinary_url | append: "v1536943052/health-commission/" %}
+{% assign path = site.cloudinary_url | append: "v2/health-commission/" %}
 {
 "placeholder": {{ path | append: "Anon.jpg" | escape | jsonify }},
 "members":[


### PR DESCRIPTION
The version number is optional. Bio photos updated today have a different version that those uploaded previously so the for loops generating those src urls was ineffective.