### PR TITLE
Feature/download pdf

### DIFF
--- a/_data/language.yml
+++ b/_data/language.yml
@@ -69,3 +69,5 @@ citation: citation
 author_list: 'By '
 search: Search
 currently_reading: You are Reading
+pdf_desktop: Download PDF
+pdf_mobile: PDF

--- a/_includes/download-pdf.html
+++ b/_includes/download-pdf.html
@@ -1,0 +1,7 @@
+{% if page.pdf.size > 0 %}
+  {% assign pdf_url = page.pdf %}
+  <div class="download-pdf">
+    <a href="{{ page.pdf }}" download="{{ page.title }}" title="{{ site.data.language.download_pdf }}"><i class="icon-download"></i>
+    <div class="download-pdf__text">{{ site.data.language.download_pdf }}</div></a>
+  </div>
+{% endif %}

--- a/_includes/download-pdf.html
+++ b/_includes/download-pdf.html
@@ -1,7 +1,10 @@
 {% if page.pdf.size > 0 %}
   {% assign pdf_url = page.pdf %}
   <div class="download-pdf">
-    <a href="{{ page.pdf }}" download="{{ page.title }}" title="{{ site.data.language.download_pdf }}"><i class="icon-download"></i>
-    <div class="download-pdf__text">{{ site.data.language.download_pdf }}</div></a>
+      <a href="{{ page.pdf }}" download="{{ page.title }}" title="{{ site.data.language.download_pdf }}">
+      <span><i class="icon-download"></i></span>
+      <span class="download-pdf__text desktop">{{ site.data.language.pdf_desktop | upcase }}</span>
+      <span class="download-pdf__text mobile">{{ site.data.language.pdf_mobile | upcase }}</span>
+    </a>
   </div>
 {% endif %}

--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -16,7 +16,6 @@
   {% else %}
   <h1 class="page-header__title" itemprop="name headline">{{ page.title | escape }}{%- if page.permalink == '/search/' -%}: <span></span>{%- endif -%}</h1>
   {% endif %}
+    {% include download-pdf.html %}
   </div>
-
 </header>
-{% include page-highlights.html %}

--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -16,6 +16,5 @@
   {% else %}
   <h1 class="page-header__title" itemprop="name headline">{{ page.title | escape }}{%- if page.permalink == '/search/' -%}: <span></span>{%- endif -%}</h1>
   {% endif %}
-    {% include download-pdf.html %}
   </div>
 </header>

--- a/_includes/page-highlights.html
+++ b/_includes/page-highlights.html
@@ -3,7 +3,7 @@
 
    {% if page.page_highlights_download %}
    <div class="page-highlights__col download-box">
-     PDF
+     {% include download-pdf.html %}
    </div>
    {% endif %}
 

--- a/_posts/2017-04-17-meeting-basic-health-needs-in-a-venezuela-in-crisis-what-roles-can-the-united-states-and-international-community-play.md
+++ b/_posts/2017-04-17-meeting-basic-health-needs-in-a-venezuela-in-crisis-what-roles-can-the-united-states-and-international-community-play.md
@@ -2,27 +2,31 @@
 title: 'Meeting Basic Health Needs in a Venezuela in Crisis: What Roles Can the United
   States and International Community Play?'
 keywords:
-- Venezuela
-is_commission_related:
-  description: ''
-  related_event: ''
-date: 2017-04-17 17:01:24 +0000
-authors:
-- _authors/test.md
+- Venzuela
+date: 2017-04-17 22:34:00 +0000
+content_type: report
 excerpt: Since 2014, Venezuela, which at one time enjoyed international recognition
   for its malaria elimination program, achievements in life expectancy, and progress
   addressing infectious diseases, has shown increasingly negative health indicators.
-content_type: report
+authors:
+- _authors/Katherine-Bliss.md
 series: ''
 themes:
 - _themes/global-disorder.md
-image: ''
-image_caption: ''
-image_credit: Getty Images
+image: https://res.cloudinary.com/csisideaslab/image/upload/v1537915123/health-commission/GettyImages-634138758.jpg
+image_caption: A health care worker carrying a banner confronts police agents during
+  a demonstration against President Nicolas Maduro's government, the lack of medicines
+  and low salaries in the country, in Caracas on February 7, 2017.
+image_credit: Federico Parra/AFP/Getty Images
 pdf: https://res.cloudinary.com/csisideaslab/image/upload/v1536944616/health-commission/170417_Bliss_HealthNeedsVenezuela_Web.pdf
+is_commission_related:
+  description: ''
+  related_event: ''
 references: ''
 
 ---
+_This commentary, by CSIS Global Health Policy Center Senior Associate Katherine Bliss, examines the relationships between disorder and health security through the case of Venezuela. Venezuela continues to experience an unprecedented humanitarian crisis, with a refugee exodus of approximately 1.8 million Venezuelans as of August 2018. Communicable diseases such as diphtheria and malaria continue to resurge within Venezuela and among the migrant and refugee populations fleeing to border countries and beyond. The implosion of the Venezuelan health sector, the mass exodus into the surrounding region, and the resurgence of disease illustrate the effects of disorder in geopolitical crises on health security._
+
 Since 2014, the Bolivarian Republic of Venezuela, which at one time enjoyed international recognition for its malaria elimination program, achievements in life expectancy, and progress addressing infectious diseases, has shown increasingly negative health indicators. While in many countries these trends might prompt intersectoral collaboration and broad public discussion regarding how to address health challenges, in Venezuela, the administration of President Nicolás Maduro has been unwilling to acknowledge the deteriorating health situation. Given Venezuela's grim economic outlook and reluctance of the Maduro administration to recognize ongoing challenges or seek external assistance for health, many experts anticipate the health situation in Venezuela will remain difficult for the foreseeable future.
 
 In responding to the health crisis in Venezuela, the United States and the international community can consider several options: they can encourage the Venezuelan government to fulfill commitments to protect the population's health and access to essential medicines; and they can support civil society organizations and professional groups providing analysis about the health sector. Strengthening the potential of public health professionals within Venezuela, as well as in the diaspora, to develop plans for reforming the health system and addressing current public health challenges should there be a political opening for them to do so will be important, as well.

--- a/_posts/2018-03-13-a-ripe-moment-for-reducing-vaccine-preventable-disease.md
+++ b/_posts/2018-03-13-a-ripe-moment-for-reducing-vaccine-preventable-disease.md
@@ -1,33 +1,47 @@
 ---
 title: A Ripe Moment for Reducing Vaccine-Preventable Disease
 keywords:
-- Vaccines
 - Immunizations
-is_commission_related:
-  description: ''
-  related_event: ''
-date: 2018-03-13 17:04:44 +0000
-authors:
-- _authors/test.md
+- Vaccines
+- Polio
+date: 2018-03-13 22:39:43 +0000
+content_type: report
 excerpt: Immunizations are one of the most effective and cost-effective health promotion
   tools, yet despite focused efforts to increase global vaccine delivery, more than
   one in ten children received no vaccines in 2016.
-content_type: report
+authors:
+- _authors/Nellie-Bristol.md
 series: ''
 themes:
 - _themes/developing-countermeasures.md
-image: ''
-image_caption: ''
-image_credit: ''
+image: https://res.cloudinary.com/csisideaslab/image/upload/v1537915314/health-commission/GettyImages-91991288.jpg
+image_caption: A picture shows vials of Humenza and Panenza, H1N1 flu vaccines by
+  the Sanofi-Pasteur manufacturer on October 19, 2009 in Val-de-Reuil, western Paris.
+  Sanofi-Pasteur produces almost ten million H1N1 vaccines per week, the most significant
+  production rate in the world. France will begin on October 20, 2009 vaccinating
+  key medical workers against swine flu and will continue the prevention campaign
+  for the general population early next month, officials said.
+image_credit: Thomas Coex/AFP/Getty Images
 pdf: https://res.cloudinary.com/csisideaslab/image/upload/v1536944822/health-commission/180313_Bristol_ARipeMoment_Web.pdf
+is_commission_related:
+  description: ''
+  related_event: ''
 references: ''
 
 ---
+_This commentary, by CSIS Global Health Policy Center Senior Fellow Nellie Bristol, focuses on vaccines, a fundamental medical countermeasure. Bristol argues for providing consistent funding for the Global Health Security Agenda and for examining the value of polio assets for global health security to ensure worthwhile infrastructure is not lost._
+
 “Immunizations are one of the most effective and cost-effective health promotion tools, improving child well-being and lowering the risk of epidemic-prone diseases. Yet despite focused efforts to increase global vaccine delivery, more than one in ten children received no vaccines in 2016, while an additional one in seven missed receiving all recommended doses and thus remains vulnerable to potentially deadly diseases.
 
-Over the next several years, three global health activities growing out of programs championed by the U.S. government will come together in a way that could catalyze immunization system improvements in the most disease-prone countries. These include immunization and disease surveillance goals outlined in the Global Health Security Agenda (GHSA) and two activities related to global polio eradication: the need for worldwide delivery of the inactivated polio vaccine; and the repurposing of the polio infrastructure for immunization and other health activities, a process known as polio transition. All three activities create concerted attention to immunization systems that could result in sustained increases in global vaccination rates and amplify U.S. investments in vaccine promotion mechanisms, such as Gavi, the Vaccine Alliance. 
+ 
+
+Over the next several years, three global health activities growing out of programs championed by the U.S. government will come together in a way that could catalyze immunization system improvements in the most disease-prone countries. These include immunization and disease surveillance goals outlined in the Global Health Security Agenda (GHSA) and two activities related to global polio eradication: the need for worldwide delivery of the inactivated polio vaccine; and the repurposing of the polio infrastructure for immunization and other health activities, a process known as polio transition. All three activities create concerted attention to immunization systems that could result in sustained increases in global vaccination rates and amplify U.S. investments in vaccine promotion mechanisms, such as Gavi, the Vaccine Alliance.
+
+ 
 
 Yet an uncertain budget future for each of the activities threatens not only the potential expansion of this global public good but could cause regression in successful vaccine delivery and related coverage rates. Although both polio eradication and the GHSA enjoy strong bipartisan support, including under the current administration, the potential for decreases in U.S. foreign assistance endangers the future of these activities. In fact, the U.S. Centers for Disease Control and Prevention is already developing staff reduction plans for the GHSA in the face of possible budget cuts.
+
+ 
 
 To capitalize on this unique opportunity to expand a valuable global health tool and avoid deterioration in immunization delivery with consequent increased risk of vaccine-preventable disease importations, the U.S. government should:
 
@@ -36,4 +50,4 @@ To capitalize on this unique opportunity to expand a valuable global health tool
 * Be an active player in polio transition planning with an eye toward encouraging countries to sustain key polio assets like immunization and surveillance systems and have a willingness to cover financing and technical gaps; and
 * Ensure continued support for vaccine delivery through Gavi and other international partners.
 
-Both the GHSA and activities related to polio eradication provide an unparalleled opportunity to save the lives of children in the developing world and protect Americans by reducing the risk of imported disease. Supporting these activities would ensure that the United States remains a leader in global health and pushes forward proven disease prevention interventions that will protect Americans at home and abroad.”
+Both the GHSA and activities related to polio eradication provide an unparalleled opportunity to save the lives of children in the developing world and protect Americans by reducing the risk of imported disease. Supporting these activities would ensure that the United States remains a leader in global health and pushes forward proven disease prevention interventions that will protect Americans at home and abroad.

--- a/_posts/2018-06-13-european-leadership-in-humanitarian-aid-and-emergency-health-response.md
+++ b/_posts/2018-06-13-european-leadership-in-humanitarian-aid-and-emergency-health-response.md
@@ -2,21 +2,14 @@
 title: European Leadership in Humanitarian Aid and Emergency Health Response
 keywords:
 - Ebola
-- Podcast
-is_commission_related:
-  description: The topics discussed on this page were informed by conversations held
-    during a Commission meeting held on [ DATE ]
-  related_event: ''
-date: 2018-06-13 17:29:33 +0000
-authors:
-- _authors/test.md
-- _authors/j-stephen-morrison.md
-- _authors/missing-author-2.md
-- _authors/author-3.md
+date: 2018-06-13 23:05:34 +0000
+content_type: commentary
 excerpt: Christos Stylianides, European Commissioner for Humanitarian Aid and Crisis
   Management and European Union Ebola Coordinator, discusses the European Union’s
   role in the May-June 2018 Ebola response.
-content_type: commentary
+authors:
+- _authors/Christos-Stylianides.md
+- _authors/stephen-morrison.md
 series: ''
 themes:
 - _themes/high-risk-disease-outbreaks.md
@@ -24,13 +17,16 @@ image: ''
 image_caption: ''
 image_credit: ''
 pdf: ''
+is_commission_related:
+  description: ''
+  related_event: ''
 references: ''
 
 ---
-[https://soundcloud.com/csis-57169780/the-global-threat-of-yellow-fever](https://soundcloud.com/csis-57169780/the-global-threat-of-yellow-fever "https://soundcloud.com/csis-57169780/the-global-threat-of-yellow-fever") 
+<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/457776030&amp;color=ff7700&amp;show_artwork=false"></iframe>
 
-_This podcast with European Commissioner for Humanitarian Aid and Crisis Management and European Union Ebola Coordinator Christos Stylianides, recorded for the CSIS Global Health Policy Center podcast series_ Take as Directed_, examines the European Union’s role in the May-June 2018 Ebola response effort, with comparisons to the 2014 Ebola response on which much of global health security today is built.  Following the recording of this podcast, the CSIS Commission hosted a private lunch discussion with Dr. Stylianides._
+_This podcast with European Commissioner for Humanitarian Aid and Crisis Management and European Union Ebola Coordinator Christos Stylianides, recorded for the CSIS Global Health Policy Center podcast series_ Take as Directed_, examines the European Union’s role in the May-June 2018 Ebola response effort, with comparisons to the 2014 Ebola response on which much of today’s understanding of global health security is built.  Following the recording of this podcast, the CSIS Commission on Strengthening America’s Health Security hosted a private lunch discussion with Dr. Stylianides._
 
-Dr. Christos Stylianides serves as the European Commissioner for Humanitarian Aid and Crisis Management and is the European Union Ebola Coordinator. In this episode of the CSIS Global Health Policy Center podcast series _Take as Directed_, Christos joins CSIS Commission Secretariat Co-Director J. Stephen Morrison to discuss how the current Ebola response has differed from the response in 2014 and the leading role that Europe is playing in that response. He also discusses his current work to expand resources for education services for children and adolescents living through crises and emergency situations. 
+Dr. Christos Stylianides serves as the European Commissioner for Humanitarian Aid and Crisis Management and is the European Union Ebola Coordinator. In this episode of the CSIS Global Health Policy Center podcast series _Take as Directed_, Dr. Stylianides joins CSIS Commission on Strengthening America’s Health Security Secretariat Director J. Stephen Morrison to discuss how the April-June 2018 Ebola response in DRC has differed from the response in 2014 and the leading role that Europe is playing in that response. He also discusses his current work to expand resources for education services for children and adolescents in crises and emergency situations.
 
-Hosted by J. Stephen Morrison. Produced by Alex Bush. Edited by Ribka Gemilangsari.
+ _Hosted by J. Stephen Morrison, produced by Alex Bush, and edited by Ribka Gemilangsari at the Center for Strategic and International Studies._

--- a/_posts/2018-06-21-the-global-threat-of-yellow-fever.md
+++ b/_posts/2018-06-21-the-global-threat-of-yellow-fever.md
@@ -2,21 +2,14 @@
 title: The Global Threat of Yellow Fever
 keywords:
 - Ebola
-- Podcast
-is_commission_related:
-  description: The topics discussed on this page were informed by conversations held
-    during a Commission meeting held on [ DATE ]
-  related_event: ''
-date: 2018-06-21 17:26:30 +0000
-authors:
-- _authors/test.md
-- _authors/j-stephen-morrison.md
-- _authors/missing-author-2.md
-- _authors/author-3.md
+date: 2018-06-21 23:03:14 +0000
+content_type: commentary
 excerpt: Daniel Lucey, a senior scholar with the O’Neill Institute for National and
   Global Health Law at Georgetown University, discusses the global threat of yellow
   fever.
-content_type: commentary
+authors:
+- _authors/Daniel-Lucey.md
+- _authors/stephen-morrison.md
 series: ''
 themes:
 - _themes/high-risk-disease-outbreaks.md
@@ -24,11 +17,16 @@ image: ''
 image_caption: ''
 image_credit: ''
 pdf: ''
+is_commission_related:
+  description: ''
+  related_event: ''
 references: ''
 
 ---
-_This podcast with Georgetown University O’Neill Institute for National and Global Health Law Senior Scholar Daniel Lucey, recorded for the CSIS Global Health Policy Center podcast series_ Take as Directed_, delves into the threat of yellow fever. In illuminating preparedness and response efforts for one particular infectious disease, Lucey offers broader lessons for high-risk disease outbreak preparedness and response, a core focus of the CSIS Commission._
+<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/461421366&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>
 
-In 2016, the World Health Organization announced that a single full dose of yellow fever vaccine would provide lifelong protection from the virus. However, due to global shortages and complicated production requirements, there has not been sufficient supply to meet the demands of recent outbreaks. Angola and the Democratic Republic of Congo in 2016 and now Brazil in 2018 have turned to using fractional doses, or about 1/5 of a full dose, as a stopgap measure—these diluted doses are only known to offer one year of protection against the virus. In this episode of the CSIS Global Health Policy Center podcast series _Take as Directed,_ Daniel Lucey, a senior scholar with the O’Neill Institute for National and Global Health Law at Georgetown University,  joins CSIS Commission Secretariat Co-Director J. Stephen Morrison to discuss the threat of yellow fever, our lack of preparedness, and the potential for a significant outbreak in Asia.
+_This podcast with Georgetown University O’Neill Institute for National and Global Health Law Senior Scholar Daniel Lucey, recorded for the CSIS Global Health Policy Center podcast series_ Take as Directed_, delves into the threat of yellow fever. In illuminating preparedness and response efforts for one particular infectious disease, Lucey offers broader lessons for high-risk disease outbreak preparedness and response, a core focus of the CSIS Commission on Strengthening America’s Health Security._
 
-Hosted by J. Stephen Morrison. Produced by Alex Bush. Edited by Ribka Gemilangsari.
+In 2016, the World Health Organization announced that a single full dose of yellow fever vaccine would provide lifelong protection from the virus. However, due to global shortages and complicated production requirements, there has not been sufficient supply to meet the demands of recent outbreaks. Angola and the Democratic Republic of Congo in 2016 and Brazil in 2018 have turned to using fractional doses, or about 1/5 of a full dose, as a stopgap measure—these diluted doses only offer one year of protection against the virus. In this episode of the CSIS Global Health Policy Center podcast series _Take as Directed,_ Daniel Lucey, a senior scholar with the O’Neill Institute for National and Global Health Law at Georgetown University,  joins CSIS Commission on Strengthening America’s Health Security Secretariat Director J. Stephen Morrison to discuss the threat of yellow fever, our lack of preparedness, and the potential for a significant outbreak in Asia.
+
+ _Hosted by J. Stephen Morrison, produced by Alex Bush, and edited by Ribka Gemilangsari at the Center for Strategic and International Studies._

--- a/_posts/2018-06-28-the-role-of-the-ifrc-in-humanitarian-response-and-preparedness.md
+++ b/_posts/2018-06-28-the-role-of-the-ifrc-in-humanitarian-response-and-preparedness.md
@@ -2,20 +2,14 @@
 title: The Role of the IFRC in Humanitarian Response and Preparedness
 keywords:
 - Ebola
-- Podcast
-is_commission_related:
-  description: ''
-  related_event: ''
-date: 2018-06-28 17:23:37 +0000
-authors:
-- _authors/test.md
-- _authors/j-stephen-morrison.md
-- _authors/missing-author-2.md
-- _authors/author-3.md
+date: 2018-06-28 23:01:49 +0000
+content_type: commentary
 excerpt: Elhadj As Sy, Secretary General of the International Federation of Red Cross
   and Red Crescent Societies (IFRC), discusses the role of the IFRC in humanitarian
   and outbreak response and preparedness.
-content_type: commentary
+authors:
+- _authors/Elhadj-Sy.md
+- _authors/stephen-morrison.md
 series: ''
 themes:
 - _themes/high-risk-disease-outbreaks.md
@@ -23,13 +17,16 @@ image: ''
 image_caption: ''
 image_credit: ''
 pdf: ''
+is_commission_related:
+  description: ''
+  related_event: ''
 references: ''
 
 ---
-[https://soundcloud.com/csis-57169780/the-role-of-the-ifrc-in-humanitarian-response-and-preparedness](https://soundcloud.com/csis-57169780/the-role-of-the-ifrc-in-humanitarian-response-and-preparedness "https://soundcloud.com/csis-57169780/the-role-of-the-ifrc-in-humanitarian-response-and-preparedness")
+<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/464633901&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>
 
-_This podcast with IFRC Secretary General Elhadj As Sy, recorded for the CSIS Global Health Policy Center podcast series_ Take as Directed_, examines global outbreak preparedness and response efforts, a critical component of global health security and an integral focus of the work of the CSIS Commission. Following the recording of this podcast, the CSIS Commission hosted a private lunch discussion with Mr. Sy._
+_This podcast with IFRC Secretary General Elhadj As Sy, recorded for the CSIS Global Health Policy Center podcast series_ Take as Directed_, examines global outbreak preparedness and response efforts, a fundamental component of global health security and an integral focus of the work of the CSIS Commission. Following the recording of this podcast, the CSIS Commission on Strengthening America’s Health Security hosted a private lunch discussion with Mr. Sy._
 
-In this episode of the CSIS Global Health Policy Center podcast series _Take as Directed_, Elhadj As Sy, Secretary General of the International Federation of Red Cross and Red Crescent Societies (IFRC), joins CSIS Commission Secretariat Co-Director J. Stephen Morrison to discuss the different roles that IFRC plays across the vast array of populations they serve, their current work on the Ebola outbreak in the Democratic Republic of Congo, and the lessons they learned from the previous outbreak. Mr. Sy has also been named co-chair of the Global Preparedness Monitoring Board, and he describes the current state of the planning for this new independent monitoring body launched by the WHO and the World Bank on May 24th at the 71st World Health Assembly.
+In this episode of the CSIS Global Health Policy Center podcast series _Take as Directed_, Elhadj As Sy, Secretary General of the International Federation of Red Cross and Red Crescent Societies (IFRC), joins CSIS Commission on Strengthening America’s Health Security Secretariat Director J. Stephen Morrison to discuss the different roles IFRC plays across the vast array of populations it serves, its work on the April-June 2018 Ebola outbreak in the Democratic Republic of Congo, and lessons learned from the 2014-215 west African Ebola outbreak. Mr. Sy has also been named co-chair of the Global Preparedness Monitoring Board, and he describes the state of the planning for this new independent health security monitoring body launched by the WHO and the World Bank on May 24th, 2018, at the 71st World Health Assembly.
 
-Hosted by J. Stephen Morrison. Produced by Alex Bush. Edited by Ribka Gemilangsari.
+_Hosted by J. Stephen Morrison, produced by Alex Bush, and edited by Ribka Gemilangsari at the Center for Strategic and International Studies._

--- a/assets/_sass/components/_download-pdf.scss
+++ b/assets/_sass/components/_download-pdf.scss
@@ -1,0 +1,24 @@
+.download-pdf {
+  margin: 0.2em;
+  padding: 0.5em;
+  display: flex;
+
+  &__text {
+    @extend %label-lg;
+    display: none;
+    a:hover & {
+      color: $color-dark-sand;
+      transition: all 0.3s ease-in-out;
+    }
+    @include breakpoint('medium') {
+      display: inline;
+    }
+  }
+
+  i {
+    color: $color-dust;
+    &:hover & {
+      color: $color-dark-sand;
+    }
+  }
+}

--- a/assets/_sass/components/_download-pdf.scss
+++ b/assets/_sass/components/_download-pdf.scss
@@ -1,24 +1,28 @@
 .download-pdf {
+  @extend %label-lg;
   margin: 0.2em;
   padding: 0.5em;
   display: flex;
 
-  &__text {
-    @extend %label-lg;
-    display: none;
-    a:hover & {
+  i {
+    color: $color-dust;
+    i:hover {
       color: $color-dark-sand;
       transition: all 0.3s ease-in-out;
     }
-    @include breakpoint('medium') {
-      display: inline;
+  }
+
+  &__text {
+    &:hover, a {
+      color: $color-dark-sand;
+      transition: all 0.3s ease-in-out;
     }
   }
 
-  i {
-    color: $color-dust;
-    &:hover & {
-      color: $color-dark-sand;
-    }
+  .mobile { display: inline; }
+  .desktop { display: none; }
+  @include breakpoint('medium') {
+    .desktop { display: inline; }
+    .mobile { display: none; }
   }
 }

--- a/assets/_sass/main.scss
+++ b/assets/_sass/main.scss
@@ -18,6 +18,7 @@
 @import 'components/buttons';
 @import 'components/forms';
 @import 'components/cite-page';
+@import 'components/download-pdf';
 @import 'components/from-commission';
 @import 'components/header-post';
 @import 'components/header-search';


### PR DESCRIPTION
- allows someone to download pdf of: test on this page: http://localhost:4000/articles/a-ripe-moment-for-reducing-vaccine-preventable-disease/
- hover styles on
- used `breakpoint(medium)`. However, because the PDF & CITE components can be resized to much smaller than the words (which causes wrap text issues and linebreaks in the text, do you think this default to larger?