### PR TITLE
Feature/related posts

### DIFF
--- a/_data/language.yml
+++ b/_data/language.yml
@@ -72,3 +72,6 @@ pdf_desktop: Download PDF
 pdf_mobile: PDF
 series:
   from: 'from '
+next_article: Next Article
+previous_article: Previous Article
+related_articles: Related Articles

--- a/_includes/post-next-by-theme.html
+++ b/_includes/post-next-by-theme.html
@@ -3,6 +3,6 @@
     {{ section_title }}
   </h3>
   {% for post in read_next %}
-    {% include post-block.html %}
+    {% include post-block.html num_themes=1 %}
   {% endfor %}
 </div>

--- a/_includes/post-next-by-theme.html
+++ b/_includes/post-next-by-theme.html
@@ -1,0 +1,17 @@
+<div class="next-by-theme">
+  <div class="next-by-theme__section-title">
+    {{ section_title }}
+  </div>
+  <div class="next-by-theme__header-type">
+    {{ include.read_next.content_type }}
+  </div>
+  <div class="next-by-theme__post-title">
+    <a href="{{ include.read_next.url | relative_url }}">{{ include.read_next.title }}</a>
+  </div>
+  <div class="next-by-theme__post-author">
+    By {% for author in include.read_next.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
+    {% assign author_info = site.authors | where: "path", author | first %}
+    {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
+  </div>
+
+</div>

--- a/_includes/post-next-by-theme.html
+++ b/_includes/post-next-by-theme.html
@@ -1,20 +1,8 @@
 <div class="next-by-theme">
-  <div class="section-title">
+  <h3 class="section-title">
     {{ section_title }}
-  </div>
-  <div class="header-type">
-    {{ read_next.content_type }}
-  </div>
-    <a class="post-title" href="{{ read_next.url | relative_url }}">{{ read_next.title }}</a>
-  <div class="post-author">
-    {% if read_next.authors.size > 0 %}
-      By {% for author in read_next.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
-      {% assign author_info = site.authors | where: "path", author | first %}
-      {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
-    {% endif %}
-  </div>
-  <div class="post-date">
-    <time datetime="{{ read_next.date | date_to_xmlschema }}" itemprop="datePublished" class="articleDate">{{ read_next.date | date: site.date_format }}</time>
-  </div>
-  {% include themes-list.html %}
+  </h3>
+  {% for post in read_next %}
+    {% include post-block.html %}
+  {% endfor %}
 </div>

--- a/_includes/post-next-by-theme.html
+++ b/_includes/post-next-by-theme.html
@@ -1,19 +1,19 @@
 <div class="next-by-theme">
-  <div class="next-by-theme__section-title">
+  <div class="section-title">
     {{ section_title }}
   </div>
-  <div class="next-by-theme__header-type">
+  <div class="header-type">
     {{ read_next.content_type }}
   </div>
-  <div class="next-by-theme__post-title">
-    <a href="{{ read_next.url | relative_url }}">{{ read_next.title }}</a>
+    <a class="post-title" href="{{ read_next.url | relative_url }}">{{ read_next.title }}</a>
+  <div class="post-author">
+    {% if read_next.authors.size > 0 %}
+      By {% for author in read_next.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
+      {% assign author_info = site.authors | where: "path", author | first %}
+      {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
+    {% endif %}
   </div>
-  <div class="next-by-theme__post-author">
-    By {% for author in read_next.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
-    {% assign author_info = site.authors | where: "path", author | first %}
-    {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
-  </div>
-  <div class="next-by-theme__post-date">
+  <div class="post-date">
     <time datetime="{{ read_next.date | date_to_xmlschema }}" itemprop="datePublished" class="articleDate">{{ read_next.date | date: site.date_format }}</time>
   </div>
   {% include themes-list.html %}

--- a/_includes/post-next-by-theme.html
+++ b/_includes/post-next-by-theme.html
@@ -3,15 +3,18 @@
     {{ section_title }}
   </div>
   <div class="next-by-theme__header-type">
-    {{ include.read_next.content_type }}
+    {{ read_next.content_type }}
   </div>
   <div class="next-by-theme__post-title">
-    <a href="{{ include.read_next.url | relative_url }}">{{ include.read_next.title }}</a>
+    <a href="{{ read_next.url | relative_url }}">{{ read_next.title }}</a>
   </div>
   <div class="next-by-theme__post-author">
-    By {% for author in include.read_next.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
+    By {% for author in read_next.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
     {% assign author_info = site.authors | where: "path", author | first %}
     {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
   </div>
-
+  <div class="next-by-theme__post-date">
+    <time datetime="{{ read_next.date | date_to_xmlschema }}" itemprop="datePublished" class="articleDate">{{ read_next.date | date: site.date_format }}</time>
+  </div>
+  {% include themes-list.html %}
 </div>

--- a/_includes/post-related-by-tag.html
+++ b/_includes/post-related-by-tag.html
@@ -13,7 +13,7 @@
     {% assign sameTagCount = 0 %}
 
     {% for tag in post.keywords %}
-      {% if post.url != page.url and post.url != include.read_next.url %}
+      {% if post.url != page.url and post.url != read_next.url %}
         {% if page.keywords contains tag %}
           {% assign sameTagCount = sameTagCount | plus: 1 %}
         {% endif %}

--- a/_includes/post-related-by-tag.html
+++ b/_includes/post-related-by-tag.html
@@ -1,0 +1,54 @@
+<div class="related-by-tag">
+  <div class="related-by-tag__section-title">
+    {{ site.data.language.related_articles }}
+  </div>
+
+  {% assign maxRelated = 2 %}
+  {% assign minCommonTags = 1 %}
+  {% assign maxRelatedCounter = 0 %}
+
+  <div class="related-by-tag__list">
+  {% for post in site[page.collection] reversed %}
+
+    {% assign sameTagCount = 0 %}
+
+    {% for tag in post.keywords %}
+      {% if post.url != page.url and post.url != include.read_next.url %}
+        {% if page.keywords contains tag %}
+          {% assign sameTagCount = sameTagCount | plus: 1 %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+
+    {% if sameTagCount >= minCommonTags %}
+      <article class="related-by-tag__list__item">
+
+        <div class="related-by-tag__list__item__header-type">
+          {{ post.content_type }}
+        </div>
+        <div class="related-by-tag__list__item__post-title">
+          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        </div>
+        <div class="related-by-tag__list__item__post-author">
+          By {% for author in post.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
+          {% assign author_info = site.authors | where: "path", author | first %}
+          {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
+        </div>
+        <div class="related-by-tag__list__item__post-date">
+          <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished" class="articleDate">{{ post.date | date: site.date_format }}</time>
+        </div>
+        {% include themes-list.html %}
+
+      </article>
+
+
+      {% assign maxRelatedCounter = maxRelatedCounter | plus: 1 %}
+
+      {% if maxRelatedCounter >= maxRelated %}
+        {% break %}
+      {% endif %}
+
+    {% endif %}
+  {% endfor %}
+  </div>
+</div>

--- a/_includes/post-related-by-tag.html
+++ b/_includes/post-related-by-tag.html
@@ -1,14 +1,14 @@
 <div class="related-by-tag">
-  <div class="section-title">
+  <h3 class="section-title">
     {{ site.data.language.related_articles }}
-  </div>
+  </h3>
 
   {% assign maxRelated = 2 %}
   {% assign minCommonTags = 1 %}
   {% assign maxRelatedCounter = 0 %}
 
   <div class="related-by-tag__list">
-  {% for post in site[page.collection] reversed %}
+  {% for post in site.posts | concat: site.events | sort: date | reversed %}
 
     {% assign sameTagCount = 0 %}
 
@@ -21,26 +21,7 @@
     {% endfor %}
 
     {% if sameTagCount >= minCommonTags %}
-      <article class="related-by-tag__list__item">
-
-        <div class="header-type">
-          {{ post.content_type }}
-        </div>
-          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        <div class="post-author">
-          {% if read_next.authors.size > 0 %}
-            By {% for author in post.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
-            {% assign author_info = site.authors | where: "path", author | first %}
-            {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
-          {% endif %}
-        </div>
-        <div class="post-date">
-          <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished" class="articleDate">{{ post.date | date: site.date_format }}</time>
-        </div>
-        {% include themes-list.html %}
-
-      </article>
-
+      {% include post-block.html %}
 
       {% assign maxRelatedCounter = maxRelatedCounter | plus: 1 %}
 
@@ -52,28 +33,19 @@
   {% endfor %}
 
   {% if maxRelatedCounter == 0 %}
-  {% assign related = next_posts | sort: date | slice: 1,2 %}
+
+    {% if next_posts.size > 1 %}
+      {% assign related = next_posts | where_exp:"item","item.url != page.url" | sort: date | slice: 1,2 %}
+    {% elsif previous_posts.size > 1 %}
+      {% assign related = previous_posts | where_exp:"item","item.url != page.url" | sort: date | reverse | slice: 1,2 %}
+    {% endif %}
+
     {% for post in related %}
-      <article class="related-by-tag__list__item">
-
-        <div class="header-type">
-          {{ post.content_type }}
-        </div>
-          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        <div class="post-author">
-          {% if read_next.authors.size > 0 %}
-            By {% for author in post.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
-            {% assign author_info = site.authors | where: "path", author | first %}
-            {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
-          {% endif %}
-        </div>
-        <div class="post-date">
-          <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished" class="articleDate">{{ post.date | date: site.date_format }}</time>
-        </div>
-        {% include themes-list.html %}
-
-      </article>
+      {% if post.url != page.url %}
+        {% include post-block.html %}
+      {% endif %}
     {% endfor %}
+
   {% endif %}
   </div>
 </div>

--- a/_includes/post-related-by-tag.html
+++ b/_includes/post-related-by-tag.html
@@ -1,5 +1,5 @@
 <div class="related-by-tag">
-  <div class="related-by-tag__section-title">
+  <div class="section-title">
     {{ site.data.language.related_articles }}
   </div>
 
@@ -23,18 +23,18 @@
     {% if sameTagCount >= minCommonTags %}
       <article class="related-by-tag__list__item">
 
-        <div class="related-by-tag__list__item__header-type">
+        <div class="header-type">
           {{ post.content_type }}
         </div>
-        <div class="related-by-tag__list__item__post-title">
-          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        <div class="post-author">
+          {% if read_next.authors.size > 0 %}
+            By {% for author in post.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
+            {% assign author_info = site.authors | where: "path", author | first %}
+            {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
+          {% endif %}
         </div>
-        <div class="related-by-tag__list__item__post-author">
-          By {% for author in post.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
-          {% assign author_info = site.authors | where: "path", author | first %}
-          {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
-        </div>
-        <div class="related-by-tag__list__item__post-date">
+        <div class="post-date">
           <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished" class="articleDate">{{ post.date | date: site.date_format }}</time>
         </div>
         {% include themes-list.html %}
@@ -50,5 +50,30 @@
 
     {% endif %}
   {% endfor %}
+
+  {% if maxRelatedCounter == 0 %}
+  {% assign related = next_posts | sort: date | slice: 1,2 %}
+    {% for post in related %}
+      <article class="related-by-tag__list__item">
+
+        <div class="header-type">
+          {{ post.content_type }}
+        </div>
+          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        <div class="post-author">
+          {% if read_next.authors.size > 0 %}
+            By {% for author in post.authors %}{% assign penultimate =  forloop.length | minus: 1 %}
+            {% assign author_info = site.authors | where: "path", author | first %}
+            {{ author_info.title }}{% unless forloop.last or forloop.length < 3 %}, {% endunless %}{% if forloop.index == penultimate %} and {% endif %}{% endfor %}
+          {% endif %}
+        </div>
+        <div class="post-date">
+          <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished" class="articleDate">{{ post.date | date: site.date_format }}</time>
+        </div>
+        {% include themes-list.html %}
+
+      </article>
+    {% endfor %}
+  {% endif %}
   </div>
 </div>

--- a/_includes/post-related-by-tag.html
+++ b/_includes/post-related-by-tag.html
@@ -21,7 +21,7 @@
     {% endfor %}
 
     {% if sameTagCount >= minCommonTags %}
-      {% include post-block.html %}
+      {% include post-block.html num_themes=1 %}
 
       {% assign maxRelatedCounter = maxRelatedCounter | plus: 1 %}
 
@@ -33,16 +33,26 @@
   {% endfor %}
 
   {% if maxRelatedCounter == 0 %}
-
+    {% assign related = "" | split: ',' %}
     {% if next_posts.size > 1 %}
-      {% assign related = next_posts | where_exp:"item","item.url != page.url" | sort: date | slice: 1,2 %}
+      {% for item in next_posts %}
+        {% if item.url != page.url and item.url != read_next[0].url %}
+          {% assign related = related | push: item %}
+        {% endif %}
+      {% endfor %}
+      {% assign related_posts = related | sort: date | slice: 0,2 %}
     {% elsif previous_posts.size > 1 %}
-      {% assign related = previous_posts | where_exp:"item","item.url != page.url" | sort: date | reverse | slice: 1,2 %}
+      {% for item in previous_posts %}
+        {% if item.url != page.url and item.url != read_next[0].url %}
+          {% assign related = related | push: item %}
+        {% endif %}
+      {% endfor %}
+      {% assign related_posts = related | sort: date | reverse | slice: 0,2 %}
     {% endif %}
 
-    {% for post in related %}
+    {% for post in related_posts | limit: 2 %}
       {% if post.url != page.url %}
-        {% include post-block.html %}
+        {% include post-block.html num_themes=1 %}
       {% endif %}
     {% endfor %}
 

--- a/_includes/post-related-posts.html
+++ b/_includes/post-related-posts.html
@@ -1,14 +1,14 @@
+{% if page.collection == 'posts' or page.collection == 'events' %}
 <div class="post__related-posts">
   {% assign previous_posts = "" | split: ',' %}
   {% assign next_posts = "" | split: ',' %}
   {% for theme in page.themes %}
-    {% assign posts = site[page.collection] %}
+    {% assign posts = site.posts | concat: site.events %}
       {% for post in posts %}
         {% if post.themes contains theme %}
           {% if post.date > page.date %}
             {% assign next_posts = next_posts | push: post %}
-          {% endif %}
-          {% if post.date < page.date %}
+          {% elsif post.date < page.date %}
             {% assign previous_posts = previous_posts | push: post %}
           {% endif %}
         {% endif %}
@@ -17,10 +17,10 @@
 
 
   {% if next_posts.size > 0 %}
-    {% assign read_next = next_posts | sort: date | first %}
+    {% assign read_next = next_posts | sort: date | slice: 0,1 %}
     {% assign section_title = site.data.language.next_article %}
-  {% else if next_posts.size == 0 %}
-    {% assign read_next = previous_posts | sort: date | reverse | slice: 1,1 | first %}
+  {% elsif next_posts.size == 0 %}
+    {% assign read_next = previous_posts | sort: date | reverse | slice: 1,1 %}
     {% assign section_title = site.data.language.previous_article %}
   {% endif %}
 
@@ -29,3 +29,4 @@
   {% include post-related-by-tag.html %}
 
 </div>
+{% endif %}

--- a/_includes/post-related-posts.html
+++ b/_includes/post-related-posts.html
@@ -5,12 +5,10 @@
   {% for theme in page.themes %}
     {% assign posts = site.posts | concat: site.events %}
       {% for post in posts %}
-        {% if post.themes contains theme %}
-          {% if post.date > page.date %}
-            {% assign next_posts = next_posts | push: post %}
-          {% elsif post.date < page.date %}
-            {% assign previous_posts = previous_posts | push: post %}
-          {% endif %}
+        {% if post.themes contains theme and post.date > page.date %}
+          {% assign next_posts = next_posts | push: post %}
+        {% elsif  post.themes contains theme and post.date < page.date %}
+          {% assign previous_posts = previous_posts | push: post %}
         {% endif %}
     {% endfor %}
   {% endfor %}
@@ -26,7 +24,7 @@
 
   {% include post-next-by-theme.html %}
 
-  {% include post-related-by-tag.html %}
+  {% include post-related-by-tag.html read_next=read_next %}
 
 </div>
 {% endif %}

--- a/_includes/post-related-posts.html
+++ b/_includes/post-related-posts.html
@@ -1,0 +1,31 @@
+<div class="post__related-posts">
+  {% assign previous_posts = "" | split: ',' %}
+  {% assign next_posts = "" | split: ',' %}
+  {% for theme in page.themes %}
+    {% assign posts = site[page.collection] %}
+      {% for post in posts %}
+        {% if post.themes contains theme %}
+          {% if post.date > page.date %}
+            {% assign next_posts = next_posts | push: post %}
+          {% endif %}
+          {% if post.date < page.date %}
+            {% assign previous_posts = previous_posts | push: post %}
+          {% endif %}
+        {% endif %}
+    {% endfor %}
+  {% endfor %}
+
+
+  {% if next_posts.size > 0 %}
+    {% assign read_next = next_posts | sort: date | first %}
+    {% assign section_title = site.data.language.next_article %}
+  {% else if next_posts.size == 0 %}
+    {% assign read_next = previous_posts | sort: date | reverse | slice: 1,1 | first %}
+    {% assign section_title = site.data.language.previous_article %}
+  {% endif %}
+
+  {% include post-next-by-theme.html read_next=read_next %}
+
+  {% include post-related-by-tag.html read_next=read_next %}
+  
+</div>

--- a/_includes/post-related-posts.html
+++ b/_includes/post-related-posts.html
@@ -24,8 +24,8 @@
     {% assign section_title = site.data.language.previous_article %}
   {% endif %}
 
-  {% include post-next-by-theme.html read_next=read_next %}
+  {% include post-next-by-theme.html %}
 
-  {% include post-related-by-tag.html read_next=read_next %}
-  
+  {% include post-related-by-tag.html %}
+
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,7 @@
       <div class="{{ wrapper_class }}">
         {{ content }}
       </div>
+      {% include post-related-posts.html %}
     </main>
 
     {%- include footer.html -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,9 +28,7 @@ layout: default
     {% include tag-list.html %}
     {% include social-share-icons.html %}
     {% include post-references.html %}
-<div class="post__authors-full">{% include authors-block.html %}</div>
-    <div class="post__related-posts">Related Posts</div>
-
+    <div class="post__authors-full">{% include authors-block.html %}</div>
   </footer>
   <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
 </article>

--- a/assets/_sass/components/_post-related-posts.scss
+++ b/assets/_sass/components/_post-related-posts.scss
@@ -82,11 +82,6 @@
       .post-title {
         @include font-size(24px);
       }
-
-      .post-date,
-      .themes-list {
-        display: none;
-      }
     }
 
     .themes-list {

--- a/assets/_sass/components/_post-related-posts.scss
+++ b/assets/_sass/components/_post-related-posts.scss
@@ -3,26 +3,22 @@
   display: flex;
   flex-wrap: wrap;
   position: relative;
-  margin-left: -#{$size-wrapper-padding-mobile};
-  margin-right: -#{$size-wrapper-padding-mobile};
   max-width: $size-wrapper-full-max-width;
 
-  &:before,
-  &:after {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 0;
-    width: calc((100vw - 100%) / 2);
-    height: 100%;
-  }
-
-  @media screen and (min-width: 90em) {
+  @include breakpoint(medium) {
     flex-wrap: nowrap;
-    margin-left: calc((#{$size-wrapper-full-max-width} - 100%) / -2);
-    margin-right: calc((#{$size-wrapper-full-max-width} - 100%) / -2);
-  }
+    margin: auto;
 
+    &:before,
+    &:after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      width: calc((100vw - 100%) / 2);
+      height: 100%;
+    }
+  }
   &:before {
     right: 99.9%;
     background-color: $color-dust;
@@ -33,61 +29,73 @@
     background-color: $color-off-white;
   }
 
+  .section-title {
+    @extend %section-title;
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+  }
+
+  .header-type {
+    @extend %post-block-meta;
+    text-transform: uppercase;
+    margin-bottom: 0.75rem;
+  }
+
+  .post-title {
+    @extend %post-block-post-title;
+    display: block;
+    margin-bottom: 0.75rem;
+  }
+
+  .post-author {
+    @extend %post-block-meta;
+  }
+
+  .post-date {
+    @extend %post-block-meta;
+    text-transform: uppercase;
+  }
+
+  .themes-list {
+    margin-top: 0.5rem;
+  }
+
   .next-by-theme {
     background-color: $color-dust;
     padding: 1.5rem $size-wrapper-padding-mobile;
     flex-basis: 100%;
 
-    @media screen and (min-width: 90em) {
+    @include breakpoint(medium) {
       padding: 1.5rem 2.5rem 3rem $size-page-content-padding;
       flex-basis: 25%;
     }
 
-    &__section-title {
-      @extend %section-title;
-      text-transform: uppercase;
-      margin-bottom: 1rem;
-    }
-
-    &__header-type {
-      @extend %post-block-meta;
-      text-transform: uppercase;
-      color: $color-white;
-      margin-bottom: 0.75rem;
-    }
-
-    &__post-title a {
-      @extend %post-block-post-title;
-      color: $color-white;
-      margin-bottom: 0.75rem;
-    }
-
-    &__post-author {
-      @extend %post-block-meta;
+    > * {
       color: $color-white;
     }
+    @include breakpoint(medium) {
+      .header-type,
+      .post-author {
+        @include font-size(16px);
+      }
 
-    &__post-date {
-      @extend %post-block-meta;
-      text-transform: uppercase;
-      color: $color-white;
+      .post-title {
+        @include font-size(24px);
+      }
 
-      @include breakpoint(medium) {
+      .post-date,
+      .themes-list {
         display: none;
       }
     }
 
     .themes-list {
-      margin-top: 0.5rem;
       a {
         color: $color-white;
         padding-left: 0;
         &:before {
           display: none;
         }
-      }
-      @include breakpoint(medium) {
-        display: none;
       }
     }
   }
@@ -97,15 +105,9 @@
     padding: 1.5rem $size-wrapper-padding-mobile;
     flex-basis: 100%;
 
-    @media screen and (min-width: 90em) {
+    @include breakpoint(medium) {
       padding: 1.5rem $size-page-content-padding 3rem 2.5rem;
       flex-basis: 75%;
-    }
-
-    &__section-title {
-      @extend %section-title;
-      text-transform: uppercase;
-      margin-bottom: 1rem;
     }
 
     &__list {
@@ -120,29 +122,9 @@
         @include breakpoint(medium) {
           flex-basis: 50%;
         }
-        &__header-type {
-          @extend %post-block-meta;
-          text-transform: uppercase;
-          margin-bottom: 0.75rem;
-        }
 
-        &__post-title a {
-          @extend %post-block-post-title;
-          margin-bottom: 0.75rem;
-        }
-
-        &__post-author {
-          @extend %post-block-meta;
-        }
-
-        &__post-date {
-          @extend %post-block-meta;
-          text-transform: uppercase;
+        .post-date {
           color: $color-warm-gray;
-        }
-
-        .themes-list {
-          margin-top: 0.5rem;
         }
 
         &:first-of-type {

--- a/assets/_sass/components/_post-related-posts.scss
+++ b/assets/_sass/components/_post-related-posts.scss
@@ -1,0 +1,139 @@
+.post__related-posts {
+  grid-column: span 2;
+  display: flex;
+  flex-wrap: wrap;
+  position: relative;
+  margin-left: -#{$size-wrapper-padding-mobile};
+  margin-right: -#{$size-wrapper-padding-mobile};
+
+  @include breakpoint(medium) {
+    flex-wrap: nowrap;
+    margin-left: -50%;
+    margin-right: -50%;
+
+    &:before,
+    &:after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      width: calc((100vw - 100%) / 2);
+      height: 100%;
+    }
+  }
+  &:before {
+    right: 100%;
+    background-color: $color-dust;
+  }
+
+  &:after {
+    left: 100%;
+    background-color: $color-off-white;
+  }
+
+  .next-by-theme {
+    background-color: $color-dust;
+    padding: $size-wrapper-padding-mobile;
+    flex-basis: 100%;
+
+    @include breakpoint(medium) {
+      padding: 1.5rem 2.5rem 3rem 0;
+      flex-basis: 25%;
+    }
+
+    &__section-title {
+      @extend %section-title;
+      text-transform: uppercase;
+      margin-bottom: 1rem;
+    }
+
+    &__header-type {
+      @extend %header-nav-link;
+      text-transform: uppercase;
+      margin-bottom: 0.75rem;
+    }
+
+    &__post-title a {
+      @extend %post-block-post-title;
+      color: $color-white;
+      margin-bottom: 0.75rem;
+    }
+
+    &__post-author {
+      @extend %header-nav-link;
+    }
+  }
+
+  .related-by-tag {
+    background-color: $color-off-white;
+    padding: $size-wrapper-padding-mobile;
+    flex-basis: 100%;
+
+    @include breakpoint(medium) {
+      padding: 1.5rem 2.5rem 3rem;
+      flex-basis: 75%;
+    }
+
+    &__section-title {
+      @extend %section-title;
+      text-transform: uppercase;
+      margin-bottom: 1rem;
+    }
+
+    &__list {
+      display: flex;
+      flex-wrap: wrap;
+      position: relative;
+      @include breakpoint(medium) {
+        flex-wrap: nowrap;
+      }
+
+      &__item {
+        @include breakpoint(medium) {
+          flex-basis: 50%;
+        }
+        &__header-type {
+          @extend %post-block-meta;
+          text-transform: uppercase;
+          margin-bottom: 0.75rem;
+        }
+
+        &__post-title a {
+          @extend %post-block-post-title;
+          margin-bottom: 0.75rem;
+        }
+
+        &__post-author {
+          @extend %post-block-meta;
+        }
+
+        &__post-date {
+          @extend %post-block-meta;
+          text-transform: uppercase;
+          color: $color-warm-gray;
+        }
+
+        @include breakpoint(medium) {
+          &:first-of-type {
+            padding-right: 2.5rem;
+          }
+
+          &:last-of-type {
+            padding-left: 2.5rem;
+            position: relative;
+
+            &:before {
+              content: '';
+              position: absolute;
+              left: -5%;
+              top: 0;
+              width: 1px;
+              height: 100%;
+              background-color: $color-dusty-lavender;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/_sass/components/_post-related-posts.scss
+++ b/assets/_sass/components/_post-related-posts.scss
@@ -5,7 +5,7 @@
   position: relative;
   max-width: $size-wrapper-full-max-width;
 
-  @include breakpoint(medium) {
+  @include breakpoint(large) {
     flex-wrap: nowrap;
     margin: auto;
 
@@ -39,6 +39,9 @@
     .post-meta__series {
       display: none;
     }
+    .post-meta__author-name {
+      text-transform: initial;
+    }
 
     &__header {
       margin-bottom: 0.5rem;
@@ -50,18 +53,27 @@
     padding: 1.5rem $size-wrapper-padding-mobile;
     flex-basis: 100%;
 
-    @include breakpoint(medium) {
-      padding: 1.5rem 2.5rem 3rem $size-page-content-padding;
+    @include breakpoint(large) {
+      padding: 2rem 2rem 2rem $size-page-content-padding;
       flex-basis: 25%;
     }
 
     > *:not(h3),
     .post-block__title a,
-    .post-meta__date {
+    .post-block__title a:visited,
+    .post-meta__date,
+    .post-meta a,
+    .post-meta a:visited,
+    .themes-list a,
+    .themes-list a:visited {
       color: $color-white;
     }
 
-    @include breakpoint(medium) {
+    .post-meta__date {
+      color: $color-beige;
+    }
+
+    @include breakpoint(large) {
       .post-meta:not(.post-meta__date) {
         @include font-size(16px);
       }
@@ -73,7 +85,6 @@
 
     .themes-list {
       a {
-        color: $color-white;
         padding-left: 0;
         &:before {
           display: none;
@@ -87,8 +98,8 @@
     padding: 1.5rem $size-wrapper-padding-mobile;
     flex-basis: 100%;
 
-    @include breakpoint(medium) {
-      padding: 1.5rem $size-page-content-padding 3rem 2.5rem;
+    @include breakpoint(large) {
+      padding: 2rem $size-page-content-padding 2rem 2rem;
       flex-basis: 75%;
     }
 
@@ -96,12 +107,12 @@
       display: flex;
       flex-wrap: wrap;
       position: relative;
-      @include breakpoint(medium) {
+      @include breakpoint(large) {
         flex-wrap: nowrap;
       }
 
       .post-block {
-        @include breakpoint(medium) {
+        @include breakpoint(large) {
           flex-basis: 50%;
         }
 
@@ -112,7 +123,7 @@
         &:first-of-type {
           padding: 0 0 3rem;
 
-          @include breakpoint(medium) {
+          @include breakpoint(large) {
             padding: 0 10% 0 0;
           }
         }
@@ -120,7 +131,7 @@
         &:last-of-type:not(:only-child) {
           position: relative;
 
-          @include breakpoint(medium) {
+          @include breakpoint(large) {
             padding: 0 0 0 2.5rem;
           }
 
@@ -131,9 +142,9 @@
             left: 0%;
             top: -1.5rem;
             height: 1px;
-            width: 100%;
+            width: calc(100vw - (#{$size-wrapper-padding-mobile} * 2));
 
-            @include breakpoint(medium) {
+            @include breakpoint(large) {
               left: -5%;
               top: 0;
               width: 1px;

--- a/assets/_sass/components/_post-related-posts.scss
+++ b/assets/_sass/components/_post-related-posts.scss
@@ -5,39 +5,41 @@
   position: relative;
   margin-left: -#{$size-wrapper-padding-mobile};
   margin-right: -#{$size-wrapper-padding-mobile};
+  max-width: $size-wrapper-full-max-width;
 
-  @include breakpoint(medium) {
-    flex-wrap: nowrap;
-    margin-left: -50%;
-    margin-right: -50%;
-
-    &:before,
-    &:after {
-      content: '';
-      display: block;
-      position: absolute;
-      top: 0;
-      width: calc((100vw - 100%) / 2);
-      height: 100%;
-    }
+  &:before,
+  &:after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    width: calc((100vw - 100%) / 2);
+    height: 100%;
   }
+
+  @media screen and (min-width: 90em) {
+    flex-wrap: nowrap;
+    margin-left: calc((#{$size-wrapper-full-max-width} - 100%) / -2);
+    margin-right: calc((#{$size-wrapper-full-max-width} - 100%) / -2);
+  }
+
   &:before {
-    right: 100%;
+    right: 99.9%;
     background-color: $color-dust;
   }
 
   &:after {
-    left: 100%;
+    left: 99.9%;
     background-color: $color-off-white;
   }
 
   .next-by-theme {
     background-color: $color-dust;
-    padding: $size-wrapper-padding-mobile;
+    padding: 1.5rem $size-wrapper-padding-mobile;
     flex-basis: 100%;
 
-    @include breakpoint(medium) {
-      padding: 1.5rem 2.5rem 3rem 0;
+    @media screen and (min-width: 90em) {
+      padding: 1.5rem 2.5rem 3rem $size-page-content-padding;
       flex-basis: 25%;
     }
 
@@ -48,8 +50,9 @@
     }
 
     &__header-type {
-      @extend %header-nav-link;
+      @extend %post-block-meta;
       text-transform: uppercase;
+      color: $color-white;
       margin-bottom: 0.75rem;
     }
 
@@ -60,17 +63,42 @@
     }
 
     &__post-author {
-      @extend %header-nav-link;
+      @extend %post-block-meta;
+      color: $color-white;
+    }
+
+    &__post-date {
+      @extend %post-block-meta;
+      text-transform: uppercase;
+      color: $color-white;
+
+      @include breakpoint(medium) {
+        display: none;
+      }
+    }
+
+    .themes-list {
+      margin-top: 0.5rem;
+      a {
+        color: $color-white;
+        padding-left: 0;
+        &:before {
+          display: none;
+        }
+      }
+      @include breakpoint(medium) {
+        display: none;
+      }
     }
   }
 
   .related-by-tag {
     background-color: $color-off-white;
-    padding: $size-wrapper-padding-mobile;
+    padding: 1.5rem $size-wrapper-padding-mobile;
     flex-basis: 100%;
 
-    @include breakpoint(medium) {
-      padding: 1.5rem 2.5rem 3rem;
+    @media screen and (min-width: 90em) {
+      padding: 1.5rem $size-page-content-padding 3rem 2.5rem;
       flex-basis: 75%;
     }
 
@@ -113,23 +141,39 @@
           color: $color-warm-gray;
         }
 
-        @include breakpoint(medium) {
-          &:first-of-type {
-            padding-right: 2.5rem;
+        .themes-list {
+          margin-top: 0.5rem;
+        }
+
+        &:first-of-type {
+          padding-bottom: 3rem;
+
+          @include breakpoint(medium) {
+            padding-right: 10%;
+          }
+        }
+
+        &:last-of-type {
+          position: relative;
+
+          @include breakpoint(medium) {
+            padding-left: 2.5rem;
           }
 
-          &:last-of-type {
-            padding-left: 2.5rem;
-            position: relative;
+          &:before {
+            content: '';
+            position: absolute;
+            background-color: $color-dusty-lavender;
+            left: 0%;
+            top: -1.5rem;
+            height: 1px;
+            width: 100%;
 
-            &:before {
-              content: '';
-              position: absolute;
+            @include breakpoint(medium) {
               left: -5%;
               top: 0;
               width: 1px;
               height: 100%;
-              background-color: $color-dusty-lavender;
             }
           }
         }

--- a/assets/_sass/components/_post-related-posts.scss
+++ b/assets/_sass/components/_post-related-posts.scss
@@ -29,35 +29,20 @@
     background-color: $color-off-white;
   }
 
-  .section-title {
-    @extend %section-title;
-    text-transform: uppercase;
-    margin-bottom: 1rem;
-  }
+  .post-block {
+    border-top: none;
+    margin-top: 1rem;
+    padding-top: 0;
+    box-sizing: content-box;
 
-  .header-type {
-    @extend %post-block-meta;
-    text-transform: uppercase;
-    margin-bottom: 0.75rem;
-  }
+    &__content,
+    .post-meta__series {
+      display: none;
+    }
 
-  .post-title {
-    @extend %post-block-post-title;
-    display: block;
-    margin-bottom: 0.75rem;
-  }
-
-  .post-author {
-    @extend %post-block-meta;
-  }
-
-  .post-date {
-    @extend %post-block-meta;
-    text-transform: uppercase;
-  }
-
-  .themes-list {
-    margin-top: 0.5rem;
+    &__header {
+      margin-bottom: 0.5rem;
+    }
   }
 
   .next-by-theme {
@@ -70,12 +55,14 @@
       flex-basis: 25%;
     }
 
-    > * {
+    > *:not(h3),
+    .post-block__title a,
+    .post-meta__date {
       color: $color-white;
     }
+
     @include breakpoint(medium) {
-      .header-type,
-      .post-author {
+      .post-meta:not(.post-meta__date) {
         @include font-size(16px);
       }
 
@@ -113,7 +100,7 @@
         flex-wrap: nowrap;
       }
 
-      &__item {
+      .post-block {
         @include breakpoint(medium) {
           flex-basis: 50%;
         }
@@ -123,18 +110,18 @@
         }
 
         &:first-of-type {
-          padding-bottom: 3rem;
+          padding: 0 0 3rem;
 
           @include breakpoint(medium) {
-            padding-right: 10%;
+            padding: 0 10% 0 0;
           }
         }
 
-        &:last-of-type {
+        &:last-of-type:not(:only-child) {
           position: relative;
 
           @include breakpoint(medium) {
-            padding-left: 2.5rem;
+            padding: 0 0 0 2.5rem;
           }
 
           &:before {

--- a/assets/_sass/main.scss
+++ b/assets/_sass/main.scss
@@ -32,6 +32,7 @@
 @import 'components/pagination';
 @import 'components/post-block';
 @import 'components/post-further-reading';
+@import 'components/post-related-posts';
 @import 'components/post-meta';
 @import 'components/tag-list';
 @import 'components/social-share-icons';


### PR DESCRIPTION
I added code to show posts from the same series when there were no posts for the same tag.
There were no Related Articles for the page at '/articles/preventing-and-responding-to-high-risk-disease-outbreaks/'

In Zeplin, the date and themes list do not show for the Next Article on desktop view, but they appear on the mobile view. I deviated from BEM a bit to make the sass shorter--abstract some of the typography without making more placeholders.