### PR TITLE
Fix/page highlights

### DIFF
--- a/INCLUDES.md
+++ b/INCLUDES.md
@@ -1,6 +1,18 @@
 # Includes Parameters
 Documentation on parameters used for includes throughout the site. For information on includes see the [Jekyll docs](https://jekyllrb.com/docs/includes/).
 
+## cite-page
+Displays the cite this page button.
+`{%- include cite-page.html classes="page-highlights__col page-higlights__cite" -%}`
+
+- `classes`: Secondary classes to attach to the component container
+
+## download-pdf
+Displays the link to download an associated PDF if there is one for a post.
+`{%- include download-pdf.html classes="page-highlights__col page-higlights__download" -%}`
+
+- `classes`: Secondary classes to attach to the component container
+
 ## img-caption
 Displays the caption and source for a photo.
 `{%- include img-caption.html tag='p' desc=page.image_caption source=page.image_credit -%}`

--- a/_data/language.yml
+++ b/_data/language.yml
@@ -27,6 +27,7 @@ single_post:
   themes_overview_btn: Read the In-Depth Overview
   related_posts: Related Posts
   more_posts: More Related Posts
+  featured_post: Featured Post
 events:
   blurb: The CSIS Commission on Strengthening America’s Health Security aims to chart
     a bold vision for the future of U.S. leadership in global health security, at

--- a/_includes/cite-page.html
+++ b/_includes/cite-page.html
@@ -1,4 +1,4 @@
-<div class="cite-page">
+<div class="cite-page {{ include.classes }}">
   <button class="cite-page__label" aria-label="{{ site.data.language.cite_page }}">
     <i class="icon-cite"></i><span class="cite-page__label__cite">{{ site.data.language.cite }}</span> <span class="cite-page__label__this-page">{{ site.data.language.this_page }}</span>
   </button>

--- a/_includes/download-pdf.html
+++ b/_includes/download-pdf.html
@@ -1,6 +1,6 @@
 {% if page.pdf.size > 0 %}
   {% assign pdf_url = page.pdf %}
-  <div class="download-pdf">
+  <div class="download-pdf {{ include.classes }}">
       <a href="{{ page.pdf }}" download="{{ page.title }}" title="{{ site.data.language.download_pdf }}">
       <span class="download-text__text"><i class="icon-download"></i></span>
       <span class="download-pdf__text download-pdf__text--desktop">{{ site.data.language.pdf_desktop }}</span>

--- a/_includes/page-highlights.html
+++ b/_includes/page-highlights.html
@@ -30,6 +30,7 @@
 
  {% if page.featured_post %}
  <div class="page-highlights__col page-highlights__col--last page-highlights__featured">
+  <h3 class="section-title">{{ site.data.language.single_post.featured_post | escape }}</h3>
   {% assign featured_post = site.posts | where: 'relative_path', page.featured_post %}
   {% for post in featured_post limit: 1 %}
     {% include post-block.html hide_excerpt=true num_themes='0' %}

--- a/_includes/page-highlights.html
+++ b/_includes/page-highlights.html
@@ -1,46 +1,41 @@
 {% if page.show_page_highlights %}
-<div class="page-highlights {{ page.collection }} {{ page.layout }} {{ page.name  | remove: ".md" }}">
+<div class="page-highlights {{ page.collection }} {{ page.layout }}">
 
-   {% if page.page_highlights_download %}
-   <div class="page-highlights__col download-box">
-     {% include download-pdf.html%}
-   </div>
-   {% endif %}
+  {% if page.page_highlights_download %}
+    {% include download-pdf.html classes="page-highlights__col page-highlights__download" %}
+  {% endif %}
 
-   {% if page.page_highlights_cite %}
-   <div class="page-highlights__col cite-box">
-     {% include cite-page.html %}
-   </div>
-   {% endif %}
-   {% if page.layout!='post'  and page.excerpt.size > 0 %}
-   <div class="page-highlights__col excerpt-box">
-     <p class="page-highlights__excerpt">
-       {{ page.excerpt }}
-      </p>
-      {%- include img-caption.html tag='p' desc=site.data.language.photo_credit source=page.image_credit -%}
+  {% if page.page_highlights_cite %}
+    {% include cite-page.html classes="page-highlights__col page-highlights__cite" %}
+  {% endif %}
 
+  {% if page.layout!='post'  and page.excerpt.size > 0 %}
+  <div class="page-highlights__col page-highlights__excerpt">
+    <p class="page__excerpt">
+      {{ page.excerpt }}
+    </p>
+    {%- include img-caption.html tag='p' desc=site.data.language.photo_credit source=page.image_credit -%}
 
-     {% if page.name == 'members.md' %}
+    {% if page.name == 'members.md' %}
       {% include about-table-contents.html %}
-     {% endif %}
+    {% endif %}
+  </div>
+  {% endif %}
 
-   </div>
-   {% endif %}
+  {% if page.page_highlights_share %}
+  <div class="page-highlights__col page-highlights__col--last ">
+   {% include social-share-icons.html %}
+ </div>
+ {% endif %}
 
-   {% if page.page_highlights_share %}
-   <div class="page-highlights__col--last ">
-     {% include social-share-icons.html %}
-   </div>
-   {% endif %}
-
-   {% if page.featured_post %}
-   <div class="page-highlights__col--last featured-box">
-      {% assign featured_post = site.posts | where: 'relative_path', page.featured_post %}
-      {% for post in featured_post limit: 1 %}
-       {% include post-block.html hide_excerpt=true num_themes='0' %}
-      {% endfor %}
-   </div>
-   {% endif %}
+ {% if page.featured_post %}
+ <div class="page-highlights__col page-highlights__col--last page-highlights__featured">
+  {% assign featured_post = site.posts | where: 'relative_path', page.featured_post %}
+  {% for post in featured_post limit: 1 %}
+    {% include post-block.html hide_excerpt=true num_themes='0' %}
+  {% endfor %}
+</div>
+{% endif %}
 
 </div>
 {% endif %}

--- a/_posts/2018-02-14-welcome-to-jekyll.markdown
+++ b/_posts/2018-02-14-welcome-to-jekyll.markdown
@@ -28,6 +28,7 @@ keywords:
 content_type: report
 pdf: http://google.com
 is_commission_related:
+  description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
   related_event: _events/commission-launch.md
 
 ---

--- a/assets/_sass/abstracts/_placeholders.scss
+++ b/assets/_sass/abstracts/_placeholders.scss
@@ -261,10 +261,15 @@
 
 %page-description {
   font-family: $font-georgia;
-  @include font-size(22px);
+  @include font-size(20px);
   font-style: italic;
-  line-height: 1.64;
+  line-height: 1.6;
   color: $color-black;
+
+  @include breakpoint('medium') {
+    @include font-size(22px);
+    line-height: 1.64;
+  }
 }
 
 %page-title {

--- a/assets/_sass/components/_cite-page.scss
+++ b/assets/_sass/components/_cite-page.scss
@@ -44,6 +44,7 @@
     @include breakpoint('medium') {
       position: absolute;
       width: 450px;
+      top: 100%;
       bottom: unset;
     }
 

--- a/assets/_sass/components/_download-pdf.scss
+++ b/assets/_sass/components/_download-pdf.scss
@@ -1,14 +1,7 @@
 .download-pdf {
   @extend %label-lg;
   text-transform: uppercase;
-  margin: 0.2em;
-  padding: 0.5em;
   display: flex;
-
-  @include breakpoint('medium') {
-    margin: 0;
-    padding: 0;
-  }
 
   i {
     color: $color-dust;

--- a/assets/_sass/components/_page-header.scss
+++ b/assets/_sass/components/_page-header.scss
@@ -13,9 +13,6 @@
   background-position: center center;
   background-size: cover;
 
-  @include breakpoint('medium') {
-  }
-
   &::before {
     content: '';
     display: block;
@@ -45,11 +42,10 @@
     position: absolute;
     left: 0;
     right: 0;
-
-    bottom: 20%;
     z-index: 5;
 
     @include breakpoint('medium') {
+      bottom: 20%;
       padding-right: calc(100% - #{$size-page-highlights-width});
     }
   }

--- a/assets/_sass/components/_page-highlights.scss
+++ b/assets/_sass/components/_page-highlights.scss
@@ -1,7 +1,7 @@
 .page-highlights {
   $ph: &;
   $cell-padding: 1rem;
-  $cell-padding-mobile: calc(#{$cell-padding} / 2);
+  $cell-padding-sides: 2rem;
 
   position: relative;
   width: calc(100% + #{$size-wrapper-padding-mobile} * 2);
@@ -74,7 +74,6 @@
       position: relative;
       top: -#{$size-page-highlights-height-desktop};
       bottom: unset;
-      margin-bottom: 2rem;
       width: $size-page-highlights-width;
       background-color: $color-off-white;
     }
@@ -99,7 +98,7 @@
     display: flex;
     align-items: flex-end;
     flex: 1 1 33%;
-    padding: $cell-padding;
+    padding: $cell-padding $cell-padding-sides;
 
     &:first-of-type {
       @include breakpoint('large') {
@@ -119,14 +118,10 @@
         position: absolute;
         background-color: $color-dusty-lavender;
         content: '';
-        height: calc(100% - #{$cell-padding-mobile});
+        height: calc(100% - #{$cell-padding});
         width: 1px;
         left: 100%;
         top: 0;
-
-        @include breakpoint('large') {
-          height: calc(100% - #{$cell-padding});
-        }
       }
     }
 
@@ -137,8 +132,8 @@
       padding-right: 0;
 
       @include breakpoint('large') {
-        padding-left: $cell-padding;
-        padding-right: $cell-padding;
+        padding-left: $cell-padding-sides;
+        padding-right: $cell-padding-sides;
       }
     }
 
@@ -161,6 +156,8 @@
 
       @include breakpoint('large') {
         display: flex;
+        flex-direction: column;
+        align-items: flex-start;
         flex-basis: 300px;
         max-width: 300px;
       }

--- a/assets/_sass/components/_page-highlights.scss
+++ b/assets/_sass/components/_page-highlights.scss
@@ -1,5 +1,8 @@
 .page-highlights {
   $ph: &;
+  $cell-padding: 1rem;
+  $cell-padding-mobile: calc(#{$cell-padding} / 2);
+
   position: relative;
   width: calc(100% + #{$size-wrapper-padding-mobile} * 2);
   left: -$size-wrapper-padding-mobile;
@@ -11,7 +14,7 @@
   min-height: #{$size-page-highlights-height-mobile};
   margin-bottom: 2rem;
 
-  @include breakpoint(medium) {
+  @include breakpoint('large') {
     width: $size-page-highlights-width;
     top: -#{$size-page-highlights-height-desktop};
     right: 0;
@@ -34,7 +37,7 @@
   }
 
   &:after {
-    @include breakpoint('medium') {
+    @include breakpoint('large') {
       content: '';
       position: absolute;
       box-shadow: 0 2px 8px 5px rgba(39, 39, 39, 0.16);
@@ -52,35 +55,94 @@
     }
   }
 
-  div[class^='page-highlights__col'] {
-    &:first-of-type {
-      padding-left: 0;
+  &.archive {
+    display: none;
 
-      @include breakpoint(medium) {
-        margin-right: auto;
+    @include breakpoint('large') {
+      display: flex;
+    }
+  }
+
+  &.posts,
+  &.events {
+    position: fixed;
+    bottom: 0;
+    margin-bottom: 0;
+    background-color: $color-white;
+
+    @include breakpoint('large') {
+      position: relative;
+      top: -#{$size-page-highlights-height-desktop};
+      bottom: unset;
+      margin-bottom: 2rem;
+      width: $size-page-highlights-width;
+      background-color: $color-off-white;
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      box-shadow: 0 2px 8px 5px rgba(39, 39, 39, 0.16);
+      top: 0;
+      right: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 1;
+
+      @include breakpoint('large') {
+        display: none;
+      }
+    }
+  }
+
+  .page-highlights__col {
+    display: flex;
+    align-items: flex-end;
+    flex: 1 1 33%;
+    padding: $cell-padding;
+
+    &:first-of-type {
+      @include breakpoint('large') {
+        padding-left: 0 !important; 
       }
     }
 
-    &:last-of-type:not(:only-child) {
+    &#{$ph}__col--last {
       background-color: $color-dust;
       flex-shrink: 0;
     }
 
-    &.download-box {
+    &#{$ph}__download {
       position: relative;
 
       &:after {
         position: absolute;
         background-color: $color-dusty-lavender;
         content: '';
-        height: 75%;
-        width: 2px;
+        height: calc(100% - #{$cell-padding-mobile});
+        width: 1px;
         left: 100%;
         top: 0;
+
+        @include breakpoint('large') {
+          height: calc(100% - #{$cell-padding});
+        }
       }
     }
 
-    #{$ph}__excerpt {
+    &#{$ph}__excerpt {
+      flex-direction: column;
+      align-items: flex-start;
+      padding-left: 0;
+      padding-right: 0;
+
+      @include breakpoint('large') {
+        padding-left: $cell-padding;
+        padding-right: $cell-padding;
+      }
+    }
+
+    .page__excerpt {
       @extend %page-description;
     }
 
@@ -93,104 +155,25 @@
         @extend %photo-caption-credit;
       }
     }
-  }
 
-  &.posts {
-    position: fixed;
-    top: calc(100vh - #{$size-page-highlights-height-mobile});
-
-    @include breakpoint(medium) {
-      position: relative;
-      top: -#{$size-page-highlights-height-desktop};
-      width: $size-page-highlights-width;
-    }
-
-    div[class^='page-highlights__col'] {
-      width: 100%;
-      display: flex;
-      align-items: flex-end;
-    }
-
-    #{$ph}__col {
-      width: 100%;
-
-      @include breakpoint(medium) {
-        flex-basis: 260px;
-      }
-
-      &--last {
-        flex-basis: 33%;
-        align-items: flex-end;
-        @include breakpoint(medium) {
-          flex-basis: 260px;
-        }
-      }
-    }
-  }
-
-  &.events,
-  &.themes {
-    &.archive {
-      #{$ph}__col--last:not(:only-child) {
-        display: none;
-        @include breakpoint(medium) {
-          display: flex;
-          flex-basis: 300px;
-        }
-      }
-    }
-
-    &:not(.archive) {
-      #{$ph}__col:not(.excerpt-box):not(.featured-box) {
-        width: 100%;
-        display: flex;
-        align-items: flex-end;
-      }
-
-      #{$ph}__col--last {
-        &:not(.featured-box) {
-          @include breakpoint(medium) {
-            display: flex;
-            flex-basis: 300px;
-            align-items: flex-end;
-          }
-        }
-      }
-    }
-  }
-
-  &.posts div[class^='page-highlights__col'],
-  &.themes div[class^='page-highlights__col'] {
-    padding: 0.5rem;
-    @include breakpoint(medium) {
-      padding: 0.5rem;
-    }
-  }
-
-  &:not(.posts):not(.events) div[class^='page-highlights__col']:first-of-type {
-    padding: 0.5rem 0;
-    @include breakpoint(medium) {
-      padding: calculate-rem(36px);
-    }
-  }
-
-  &.events,
-  &.posts {
-    .page-highlights__col {
-      width: 100%;
-      align-items: flex-end;
-    }
-  }
-
-  &.events,
-  &.themes {
-    #{$ph}__col--last {
+    &#{$ph}__featured {
       display: none;
 
-      @include breakpoint(medium) {
+      @include breakpoint('large') {
         display: flex;
         flex-basis: 300px;
+        max-width: 300px;
       }
+    }
+  }
+
+  &.events .page-highlights__col--last {
+    flex-basis: 33%;
+    max-width: 33%;
+
+    @include breakpoint('large') {
+      flex-basis: 300px;
+      max-width: 300px;
     }
   }
 }

--- a/assets/_sass/components/_post-block.scss
+++ b/assets/_sass/components/_post-block.scss
@@ -36,6 +36,7 @@
 
     .page-highlights & {
       @extend %post-block-post-title-featured;
+      margin-top: 0;
 
       a {
         color: $color-white;

--- a/assets/_sass/components/_post-meta.scss
+++ b/assets/_sass/components/_post-meta.scss
@@ -42,6 +42,10 @@
     .page-header & {
       border-bottom: 1px solid $color-dusty-lavender;
     }
+
+    .page-highlights & {
+      display: none;
+    }
   }
 
   #{$p}__content-type,
@@ -52,6 +56,10 @@
 
   &__date {
     color: $color-warm-gray;
+
+    .page-highlights & {
+      color: $color-beige;
+    }
   }
 
   &__series {

--- a/assets/_sass/components/_social-share-icons.scss
+++ b/assets/_sass/components/_social-share-icons.scss
@@ -47,6 +47,8 @@
   }
 
   .page-highlights & {
+    padding: 0;
+    
     #{$s}__text {
       color: $color-white;
     }


### PR DESCRIPTION
This cleans up the page highlights component by making styles (especially spacing and margin) consistent. Instead of nesting the download PDF and citation components inside two divs, I created a parameter that allowed me to pass the necessary classes for the page highlights to them so they are sibling elements. I also made other assorted design and style tweaks.