### PR TITLE
fixed header image caption (new branch)

### DIFF
--- a/_includes/img-caption.html
+++ b/_includes/img-caption.html
@@ -1,5 +1,5 @@
 <{{ include.tag | default: 'figcaption' }} class="img-caption">
-{{ include.desc }}
+{{ include.desc | default: site.data.language.photo_credit }}
 {% if include.source %}
   <span class="img-caption__source">{{ include.source | prepend: ' ' }}</span>
 {% endif %}

--- a/_includes/page-highlights.html
+++ b/_includes/page-highlights.html
@@ -14,7 +14,11 @@
     <p class="page__excerpt">
       {{ page.excerpt }}
     </p>
-    {%- include img-caption.html tag='p' desc=site.data.language.photo_credit source=page.image_credit -%}
+    {% if page.header_image_caption.size > 0 or page.header_image_credit.size > 0 %}
+      {%- include img-caption.html tag='p' desc=page.header_image_caption source=page.header_image_credit -%}
+    {% else %}
+      {%- include img-caption.html tag='p' desc=site.data.language.photo_credit source=page.image_credit -%}
+    {% endif %}
 
     {% if page.name == 'members.md' %}
       {% include about-table-contents.html %}


### PR DESCRIPTION
- fixed logic in `page-highlights` and added default value to `desc` in `img-caption.html` include.

(a new branch was made, because the other was compromised.)