### PR TITLE
fixed: floating author photo over page highlights

### DIFF
--- a/assets/_sass/components/_author-photo-tint.scss
+++ b/assets/_sass/components/_author-photo-tint.scss
@@ -5,7 +5,7 @@
   border-radius: 50%;
   padding: none;
   position: relative;
-  z-index: 10;
+  z-index: 5;
 
   .authors-block & {
     width: $size-author-image-block;

--- a/assets/_sass/components/_page-highlights.scss
+++ b/assets/_sass/components/_page-highlights.scss
@@ -7,7 +7,7 @@
   width: calc(100% + #{$size-wrapper-padding-mobile} * 2);
   left: -$size-wrapper-padding-mobile;
   padding: 0 $size-wrapper-padding-mobile;
-  z-index: 5;
+  z-index: 10;
   display: flex;
   position: relative;
   background-color: $color-off-white;
@@ -108,7 +108,7 @@
 
     &:first-of-type {
       @include breakpoint('large') {
-        padding-left: 0 !important; 
+        padding-left: 0 !important;
       }
     }
 


### PR DESCRIPTION
Author photo in header block was previously floating over page highlights in mobile. Changed the `z-index` of `author-tint` to 5, and the z-index of `page-highlights` to 10, so that highlights are always displaying over the author block photos.