### PR TITLE
remove max-height from img

### DIFF
--- a/assets/_sass/components/_404.scss
+++ b/assets/_sass/components/_404.scss
@@ -104,7 +104,7 @@
             height: auto;
             display: block;
             margin: 0 200% 0 -200%;
-
+            max-width: initial;
             padding-bottom: 0;
             position: absolute;
             filter: progid:DXImageTransform.Microsoft.Blur(PixelRadius="3");


### PR DESCRIPTION
I just noticed that a global max-height:100% on img was messing up the 404 animation. The img in the animation needs to be 115%