### PR TITLE
only includes related post button if there are more than post_list_limit

### DIFF
--- a/_includes/themes-related-posts.html
+++ b/_includes/themes-related-posts.html
@@ -11,5 +11,7 @@
   {% for post in theme_posts limit: post_list_limit %}
   {% include post-block.html %}
   {% endfor %}
+  {% if theme_posts.size > 3 %}
   <a href="{{ site.theme_url | append: page.short_title }}" class="btn btn--dark-gray themes__more-posts">{{ site.data.language.single_post.more_posts }}</a>
+  {% endif %}
 </div>

--- a/_includes/themes-related-posts.html
+++ b/_includes/themes-related-posts.html
@@ -11,7 +11,7 @@
   {% for post in theme_posts limit: post_list_limit %}
   {% include post-block.html %}
   {% endfor %}
-  {% if theme_posts.size > 3 %}
+  {% if theme_posts.size > post_list_limit %}
   <a href="{{ site.theme_url | append: page.short_title }}" class="btn btn--dark-gray themes__more-posts">{{ site.data.language.single_post.more_posts }}</a>
   {% endif %}
 </div>


### PR DESCRIPTION
A question about this logic: I could have made the 'related post button' only display if the `theme_posts.size > 3`. But is it more modular to display the button when it's greater than the `post-list-limit? 

If you have the time, what is the reason why the `post_list_limit` is equal to 2 when there is a featured post?