### PR TITLE
fix/insert-photos

### DIFF
--- a/about.md
+++ b/about.md
@@ -14,8 +14,8 @@ credits: <em>Health Commission</em> is a product of the <a href="https://www.csi
   Studies.
 funder_acknowledgements: This project is funded through the generous support of the
   Bill & Melinda Gates Foundation.
-header_image: https://res.cloudinary.com/csisideaslab/image/upload/v1537899884/health-commission/About_Header_Photo.jpg
-post_image: https://res.cloudinary.com/csisideaslab/image/upload/v1537904699/health-commission/About_Smaller_Photo.jpg
+header_image: https://res.cloudinary.com/csisideaslab/image/upload/v1548438225/health-commission/About_Header_Photo.jpg
+post_image: https://res.cloudinary.com/csisideaslab/image/upload/v1548438055/health-commission/About_Smaller_Photo.jpg
 post_image_credit: Liz Lynch
 post_image_caption: Commission co-chairs Kelly Ayotte and Julie Gerberding at the
   April 17, 2018 Commission launch.

--- a/assets/_sass/pages/_home.scss
+++ b/assets/_sass/pages/_home.scss
@@ -158,7 +158,7 @@
     position: relative;
     min-height: 220px;
     background-color: $color-off-white;
-    background-image: url('https://res.cloudinary.com/csisideaslab/image/upload/v1537899884/health-commission/About_Header_Photo.jpg');
+    background-image: url('https://res.cloudinary.com/csisideaslab/image/upload/v1548438225/health-commission/About_Header_Photo.jpg');
     background-repeat: no-repeat;
     background-position: center center;
     background-size: cover;


### PR DESCRIPTION
Fixed the photo size, and replaced the urls in the front matter. 

Just a note, but the insert photo is set to resize to 800px at the large screen size, not 700px. Figured I'd mention it!

![screen shot 2019-01-25 at 1 08 59 pm](https://user-images.githubusercontent.com/18509789/51764349-fc3a9800-20a2-11e9-8fd6-aa0bf36f8b32.png)
